### PR TITLE
📦 atlas-experiment-table 💬 Bugfix #171767237 – Table footer shows `Infinity` in total number of pages if all rows are displayed

### DIFF
--- a/packages/atlas-experiment-table/__test__/TableFooter.test.js
+++ b/packages/atlas-experiment-table/__test__/TableFooter.test.js
@@ -74,6 +74,22 @@ describe(`TableFooter`, () => {
     expect(wrapper.find(`li`).at(8)).toHaveText(`Next`)
   })
 
+  test(`shows only 1 when all rows`, () => {
+    const filteredDataRowsLength = getRandomInt(props.rowsPerPage * MAX_PAGE_ITEMS_COUNT + 1, props.rowsPerPage * 20)
+    const wrapper =
+      shallow(
+        <TableFooter
+          {...props}
+          dataRowsLength={filteredDataRowsLength}
+          filteredDataRowsLength={filteredDataRowsLength}
+          rowsPerPage={0}/>)
+
+    expect(wrapper.find(`li`)).toHaveLength(3)
+    expect(wrapper.find(`li`).at(0)).toHaveText(`Previous`)
+    expect(wrapper.find(`li`).at(1)).toHaveText(`1`)
+    expect(wrapper.find(`li`).at(2)).toHaveText(`Next`)
+  })
+
   test(`shows the first page itemes anchored at N if data rows spans ${MAX_PAGE_ITEMS_COUNT} or more pages`, () => {
     const filteredDataRowsLength = getRandomInt(props.rowsPerPage * MAX_PAGE_ITEMS_COUNT + 1, props.rowsPerPage * 20)
     const wrapper =

--- a/packages/atlas-experiment-table/src/TableFooter.js
+++ b/packages/atlas-experiment-table/src/TableFooter.js
@@ -20,9 +20,12 @@ const TableFooter =
 
   let restyledPages = pagination.pages
 
-  // An edge case where paginate gets all wonky
+  // A couple of edge cases where jw-paginate gets all wonky
   if (filteredDataRowsLength === 0) {
     restyledPages = []
+  } else if (rowsPerPage === 0) {
+    restyledPages = [1]
+    pagination.totalPages = 1
   }
 
   // Replace first and last pages with 1 and n if they’re not visible in the default 7 items
@@ -56,7 +59,7 @@ const TableFooter =
         <ul className={`pagination`} style={{ textAlign: `right`}}>
           <li>
             {
-              currentPage === 1 ?
+              filteredDataRowsLength === 0 || currentPage === 1 ?
                 <span className={`disabled`}>Previous</span> :
                 <a onClick={() => onChange(currentPage - 1)}>Previous</a>
             }
@@ -82,7 +85,7 @@ const TableFooter =
           }
           <li>
             {
-              filteredDataRowsLength <= currentPage * rowsPerPage ?
+              filteredDataRowsLength === 0 || currentPage === pagination.totalPages ?
                 <span className={`disabled`}>Next</span> :
                 <a onClick={() => onChange(currentPage + 1)}>Next</a>
             }

--- a/packages/atlas-experiment-table/src/TableManager.js
+++ b/packages/atlas-experiment-table/src/TableManager.js
@@ -207,17 +207,17 @@ export default class TableManager extends React.Component {
   }
 
   render() {
-    const { rowsPerPage, currentPage, filteredSortedDataRows } = this.state
+    const { rowsPerPage, currentPage } = this.state
     const currentPageDataRows = rowsPerPage ?
-      filteredSortedDataRows.slice(rowsPerPage * (currentPage - 1), rowsPerPage * currentPage) :
-      filteredSortedDataRows
+      this.state.filteredSortedDataRows.slice(rowsPerPage * (currentPage - 1), rowsPerPage * currentPage) :
+      this.state.filteredSortedDataRows
 
     return (
       <div className={this.props.className}>
         <TablePreamble
           dropdowns={this.state.dropdownFilters}
           dropdownOnChange={this.updateFilters}
-          rowsCount={this.props.dataRows.length}
+          rowsCount={this.state.filteredSortedDataRows.length}
           rowsPerPageOptions={this.rowsPerPageOptions}
           rowsPerPage={this.state.rowsPerPage}
           rowsPerPageOnChange={this.updateRowsPerPage}
@@ -239,7 +239,7 @@ export default class TableManager extends React.Component {
 
         <TableFooter
           dataRowsLength={this.props.dataRows.length}
-          filteredDataRowsLength={filteredSortedDataRows.length}
+          filteredDataRowsLength={this.state.filteredSortedDataRows.length}
           currentPage={this.state.currentPage}
           rowsPerPage={this.state.rowsPerPage}
           onChange={i => this.setState({ currentPage: i })}/>


### PR DESCRIPTION
We need to handle the case of all rows shown (`rowsPerPage` is 0) as a special one, we can’t rely on the logic of `jw-paginate`.