### PR TITLE
📦 scxa-gene-search-form 💬 Feature #171953862 – Add gene search form to CCA

### DIFF
--- a/packages/scxa-gene-search-form/__test__/Autocomplete.test.js
+++ b/packages/scxa-gene-search-form/__test__/Autocomplete.test.js
@@ -80,6 +80,18 @@ describe(`Autocomplete suggestions fetch`, () => {
 
     expect(fetchMock.calls()).toHaveLength(1)
     expect(URI(fetchMock.lastUrl()).search(true)).toHaveProperty(`species`, species.join(`,`))
+  })
 
+  test(`can hide the label if we pass an empty string`, () => {
+    const wrapper = shallow(<Autocomplete {...props} labelText={``} />)
+
+    expect(wrapper).not.toContainMatchingElement(`label`)
+  })
+
+  test(`can customise the label`, () => {
+    const labelText = `COVID-19 UK lockdown day 2`
+    const wrapper = shallow(<Autocomplete {...props} labelText={labelText} />)
+
+    expect(wrapper.find(`label`)).toHaveText(labelText)
   })
 })

--- a/packages/scxa-gene-search-form/__test__/Autocomplete.test.js
+++ b/packages/scxa-gene-search-form/__test__/Autocomplete.test.js
@@ -13,7 +13,8 @@ const getRandomInt = (max) => Math.floor(Math.random() * Math.floor(max))
 const props = {
   atlasUrl: `foo/`,
   suggesterEndpoint: `suggest`,
-  onChange: () => {}
+  onChange: () => {},
+  labelText: `Foobar:`
 }
 
 const defaultValue = {

--- a/packages/scxa-gene-search-form/__test__/__snapshots__/Autocomplete.test.js.snap
+++ b/packages/scxa-gene-search-form/__test__/__snapshots__/Autocomplete.test.js.snap
@@ -5,7 +5,7 @@ exports[`Autocomplete matches snapshot 1`] = `
   <label
     htmlFor="geneQuery"
   >
-    Gene ID or gene symbol
+    Foobar:
   </label>
   <div
     className=" css-2b097c-container"

--- a/packages/scxa-gene-search-form/__test__/__snapshots__/GeneSearchForm.test.js.snap
+++ b/packages/scxa-gene-search-form/__test__/__snapshots__/GeneSearchForm.test.js.snap
@@ -146,7 +146,7 @@ exports[`GeneSearchForm matches snapshot 1`] = `
               className=" css-1hb7zxy-IndicatorsContainer"
             >
               <span
-                className="sc-AxjAm bxcukt"
+                className="sc-bdVaJa jcfyVD"
                 cx={[Function]}
               />
             </div>

--- a/packages/scxa-gene-search-form/__test__/__snapshots__/LabelledSelect.test.js.snap
+++ b/packages/scxa-gene-search-form/__test__/__snapshots__/LabelledSelect.test.js.snap
@@ -40,7 +40,7 @@ exports[`LabelledSelect matches snapshot 1`] = `
         className=" css-1hb7zxy-IndicatorsContainer"
       >
         <span
-          className="sc-AxjAm bxcukt"
+          className="sc-bdVaJa jcfyVD"
           cx={[Function]}
         />
       </div>

--- a/packages/scxa-gene-search-form/package-lock.json
+++ b/packages/scxa-gene-search-form/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "scxa-gene-search-form",
-	"version": "1.5.0",
+	"version": "1.6.0-beta.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/scxa-gene-search-form/package-lock.json
+++ b/packages/scxa-gene-search-form/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "scxa-gene-search-form",
-	"version": "1.6.0-beta.1",
+	"version": "1.6.0-beta.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/scxa-gene-search-form/package.json
+++ b/packages/scxa-gene-search-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/scxa-gene-search-form",
-  "version": "1.6.0-beta.1",
+  "version": "1.6.0-beta.2",
   "description": "Single Cell Expression Atlas homepage gene search form",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/scxa-gene-search-form/package.json
+++ b/packages/scxa-gene-search-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/scxa-gene-search-form",
-  "version": "1.5.0",
+  "version": "1.6.0-beta.1",
   "description": "Single Cell Expression Atlas homepage gene search form",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/scxa-gene-search-form/src/Autocomplete.js
+++ b/packages/scxa-gene-search-form/src/Autocomplete.js
@@ -19,7 +19,12 @@ const _asyncFetchOptions = (atlasUrl, suggesterEndpoint, selectedSpecies, allSpe
     throw new Error(`${suggesterUrl} => ${response.status}`)
   }
 
-const Autocomplete = ({atlasUrl, suggesterEndpoint, selectedSpecies, allSpecies, onChange, defaultValue}) => {
+const Autocomplete = (
+  {
+    atlasUrl, suggesterEndpoint,
+    selectedSpecies, allSpecies, onChange, defaultValue,
+    labelText
+  }) => {
   const _defaultValue = defaultValue.term && defaultValue.term.trim() ?
     {
       label: defaultValue.term.trim(),
@@ -31,7 +36,7 @@ const Autocomplete = ({atlasUrl, suggesterEndpoint, selectedSpecies, allSpecies,
 
   return (
     <div>
-      <label htmlFor={`geneQuery`}>Gene ID or gene symbol</label>
+      <label htmlFor={`geneQuery`}>{labelText}</label>
       <AsyncCreatableSelect
         name={`geneQuery`}
         components={{ DropdownIndicator: null, IndicatorSeparator: null }}
@@ -64,7 +69,8 @@ Autocomplete.propTypes = {
   defaultValue: PropTypes.shape({
     term: PropTypes.string,
     category: PropTypes.string
-  })
+  }),
+  labelText: PropTypes.string.isRequired
 }
 
 Autocomplete.defaultProps = {

--- a/packages/scxa-gene-search-form/src/Autocomplete.js
+++ b/packages/scxa-gene-search-form/src/Autocomplete.js
@@ -36,7 +36,7 @@ const Autocomplete = (
 
   return (
     <div>
-      <label htmlFor={`geneQuery`}>{labelText}</label>
+      {labelText && <label htmlFor={`geneQuery`}>{labelText}</label>}
       <AsyncCreatableSelect
         name={`geneQuery`}
         components={{ DropdownIndicator: null, IndicatorSeparator: null }}

--- a/packages/scxa-gene-search-form/src/FetchLoader.js
+++ b/packages/scxa-gene-search-form/src/FetchLoader.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import URI from 'urijs'
 
 import GeneSearchForm from './GeneSearchForm'
@@ -21,10 +20,10 @@ class FetchLoader extends React.Component {
     return(
       error ?
         <GeneSearchForm {...data} {...this.props} speciesSelectStatusMessage={`${error.name}: ${error.message}`}/> :
-      loading ?
-        <GeneSearchForm {...data} {...this.props} speciesSelectStatusMessage={`Fetching species…`}/> :
-      // promise fulfilled
-        <GeneSearchForm {...data} {...this.props} />
+        loading ?
+          <GeneSearchForm {...data} {...this.props} speciesSelectStatusMessage={`Fetching species…`}/> :
+          // promise fulfilled
+          <GeneSearchForm {...data} {...this.props} />
     )
   }
 
@@ -68,37 +67,7 @@ class FetchLoader extends React.Component {
   }
 }
 
-FetchLoader.propTypes = {
-  atlasUrl: PropTypes.string.isRequired,
-  wrapperClassName: PropTypes.string,
-  actionEndpoint: PropTypes.string.isRequired,
-  onSubmit: PropTypes.func,
-
-  autocompleteClassName: PropTypes.string,
-  suggesterEndpoint: PropTypes.string.isRequired,
-  defaultValue: PropTypes.shape({
-    term: PropTypes.string,
-    category: PropTypes.string
-  }),
-
-  enableSpeciesSelect: PropTypes.bool,
-  speciesEndpoint: PropTypes.string,
-  speciesSelectClassName: PropTypes.string,
-  defaultSpecies: PropTypes.string,
-
-  searchExamples: PropTypes.arrayOf(PropTypes.shape({
-    text: PropTypes.string.isRequired,
-    url: PropTypes.string.isRequired
-  }))
-}
-
-FetchLoader.defaultProps = {
-  autocompleteClassName: ``,
-  defaultValue: {},
-  enableSpeciesSelect: false,
-  speciesEndpoint: ``,
-  speciesSelectClassName: ``,
-  defaultSpecies: ``
-}
+FetchLoader.propTypes = GeneSearchForm.propTypes
+FetchLoader.defaultProps = GeneSearchForm.defaultProps
 
 export default FetchLoader

--- a/packages/scxa-gene-search-form/src/GeneSearchForm.js
+++ b/packages/scxa-gene-search-form/src/GeneSearchForm.js
@@ -43,7 +43,7 @@ class GeneSearchForm extends React.Component {
   render() {
     const {wrapperClassName, actionEndpoint, onSubmit, searchExamples} = this.props
 
-    const {autocompleteClassName, atlasUrl, suggesterEndpoint, defaultValue} = this.props
+    const {autocompleteClassName, atlasUrl, suggesterEndpoint, defaultValue,autocompleteLabel} = this.props
 
     const {enableSpeciesSelect, speciesSelectClassName, speciesSelectStatusMessage} = this.props
     const {allSpecies, topSpecies} = this.props
@@ -58,7 +58,8 @@ class GeneSearchForm extends React.Component {
               onChange={this.autocompleteOnChange}
               selectedSpecies={this.state.selectedSpecies}
               allSpecies={allSpecies}
-              defaultValue={defaultValue}/>
+              defaultValue={defaultValue}
+              labelText={autocompleteLabel}/>
           </div>
           { enableSpeciesSelect &&
             <div className={speciesSelectClassName}>
@@ -105,6 +106,7 @@ GeneSearchForm.propTypes = {
   onSubmit: PropTypes.func,
   wrapperClassName: PropTypes.string,
 
+  autocompleteLabel: PropTypes.string,
   autocompleteClassName: PropTypes.string,
   suggesterEndpoint: PropTypes.string.isRequired,
   defaultValue: PropTypes.shape({
@@ -126,6 +128,7 @@ GeneSearchForm.propTypes = {
 }
 
 GeneSearchForm.defaultProps = {
+  autocompleteLabel: `Gene ID or gene symbol`,
   wrapperClassName: ``,
   autocompleteClassName: ``,
   defaultValue: {},

--- a/packages/scxa-gene-search-form/src/index.js
+++ b/packages/scxa-gene-search-form/src/index.js
@@ -1,3 +1,11 @@
-import FetchLoader from './FetchLoader.js'
 
-export default FetchLoader
+import React from 'react'
+import ReactDOM from 'react-dom'
+
+import GeneSearchFormWithFetchLoader from './FetchLoader'
+
+const render = (options, target) => {
+  ReactDOM.render(<GeneSearchFormWithFetchLoader {...options} />, document.getElementById(target))
+}
+
+export { GeneSearchFormWithFetchLoader as default, render }


### PR DESCRIPTION
For Cambridge Cell Atlas, having a text label on top of the text input doesn’t look very good:
![image](https://user-images.githubusercontent.com/4425744/77527371-e7fb5200-6e83-11ea-96bb-6d70c5f7a860.png)

So I added a prop so that we can hide it.