### PR TITLE
📦 atlas-experiment-table 💬 Bugfix #172189793 – Canis familiaris can’t find Canis lupus familiaris

### DIFF
--- a/packages/atlas-experiment-table/__test__/TableManager.test.js
+++ b/packages/atlas-experiment-table/__test__/TableManager.test.js
@@ -15,6 +15,7 @@ import {
   bulkTableHeaders, bulkDropdownFilters, bulkRowSelectionColumn,
   singleCellTableHeaders, singleCellDropdownFilters, singleCellRowSelectionColumn, downloadFileTypes
 } from './TestUtils'
+
 import bulkExperiments from './experiments-bulk.json'
 import singleCellExperiments from './experiments-sc.json'
 

--- a/packages/atlas-experiment-table/__test__/search.test.js
+++ b/packages/atlas-experiment-table/__test__/search.test.js
@@ -66,13 +66,12 @@ describe(`Search function`, () => {
 
     expect(searchResults1.length).toBeGreaterThan(0)
     expect(searchResults2.length).toBeGreaterThan(0)
-    expect(searchResults12.length).toBeGreaterThan(searchResults1.length)
-    expect(searchResults12.length).toBeGreaterThan(searchResults2.length)
+    expect(searchResults12.length).toBeGreaterThanOrEqual(searchResults1.length)
+    expect(searchResults12.length).toBeGreaterThanOrEqual(searchResults2.length)
 
     expect(searchResults12).toHaveLength(searchResults21.length)
     expect(searchResults12).toHaveLength(searchResults21Foobar.length)
   })
-
 
   test(`can search for exact phrases enclosing query in double quotes`, () => {
     const dataKey = getRandomTextFieldDataKey(bulkExperiments)

--- a/packages/atlas-experiment-table/__test__/search.test.js
+++ b/packages/atlas-experiment-table/__test__/search.test.js
@@ -1,7 +1,9 @@
 import _ from 'lodash'
-import search from '../src/search'
+import search, { TOKEN_MIN_LENGTH } from '../src/search'
 
 import bulkExperiments from './experiments-bulk.json'
+
+import { randomSubstring } from './TestUtils'
 
 const getRandomValueFromKeyedRows = (dataRows, dataKey) =>
   _.chain(dataRows)
@@ -19,6 +21,20 @@ const getRandomTextFieldDataKey = dataRows =>
     .value()
 
 describe(`Search function`, () => {
+  test(`can match long enough substrings`, () => {
+    let dataKey
+    let queryString = ``
+    while (queryString.length < TOKEN_MIN_LENGTH) {
+      dataKey = getRandomTextFieldDataKey(bulkExperiments)
+      queryString = randomSubstring(getRandomValueFromKeyedRows(bulkExperiments, dataKey))
+    }
+
+    const searchResults = bulkExperiments.filter(bulkExperiment => search(bulkExperiment, dataKey, queryString))
+
+    expect(searchResults.length).toBeGreaterThan(0)
+    expect(searchResults.length).toBeLessThan(bulkExperiments.length)
+  })
+
   test(`is case insensitive`, () => {
     const dataKey = getRandomTextFieldDataKey(bulkExperiments)
     const queryString = getRandomValueFromKeyedRows(bulkExperiments, dataKey)

--- a/packages/atlas-experiment-table/__test__/search.test.js
+++ b/packages/atlas-experiment-table/__test__/search.test.js
@@ -1,0 +1,77 @@
+import _ from 'lodash'
+import search from '../src/search'
+
+import bulkExperiments from './experiments-bulk.json'
+
+const getRandomValueFromKeyedRows = (dataRows, dataKey) =>
+  _.chain(dataRows)
+    .map(dataRow => _.pick(dataRow, dataKey))
+    .flatMapDeep(_.values)
+    .sample()
+    .value()
+
+const getRandomTextFieldDataKey = dataRows =>
+  _.chain(dataRows)
+    .map(dataRow => _.pickBy(dataRow, _.isString))
+    .flatMap(_.keys)
+    .uniq()
+    .sample()
+    .value()
+
+describe(`Search function`, () => {
+  test(`is case insensitive`, () => {
+    const dataKey = getRandomTextFieldDataKey(bulkExperiments)
+    const queryString = getRandomValueFromKeyedRows(bulkExperiments, dataKey)
+    const searchResults = bulkExperiments.filter(bulkExperiment => search(bulkExperiment, dataKey, queryString))
+    const searchResultsUpper =
+      bulkExperiments.filter(bulkExperiment => search(bulkExperiment, dataKey, queryString.toUpperCase()))
+    const searchResultsLower =
+      bulkExperiments.filter(bulkExperiment => search(bulkExperiment, dataKey, queryString.toLowerCase()))
+
+    expect(searchResults).toHaveLength(searchResultsUpper.length)
+    expect(searchResults).toHaveLength(searchResultsLower.length)
+    expect(searchResults.length).toBeGreaterThan(0)
+  })
+
+  test(`can search multiple results separating query terms with spaces`, () => {
+    const dataKey = getRandomTextFieldDataKey(bulkExperiments)
+    const queryString1 = getRandomValueFromKeyedRows(bulkExperiments, dataKey)
+    const queryString2 = getRandomValueFromKeyedRows(bulkExperiments, dataKey)
+    const searchResults1 = bulkExperiments.filter(bulkExperiment => search(bulkExperiment, dataKey, queryString1))
+    const searchResults2 = bulkExperiments.filter(bulkExperiment => search(bulkExperiment, dataKey, queryString2))
+
+    const searchResults12 =
+      bulkExperiments.filter(bulkExperiment => search(bulkExperiment, dataKey, `${queryString1} ${queryString2}`))
+    const searchResults21 =
+      bulkExperiments.filter(bulkExperiment => search(bulkExperiment, dataKey, `${queryString2} ${queryString1}`))
+    const searchResults21Foobar =
+      bulkExperiments.filter(
+        bulkExperiment => search(bulkExperiment, dataKey, `${queryString2} foobar ${queryString1}`))
+
+    expect(searchResults1.length).toBeGreaterThan(0)
+    expect(searchResults2.length).toBeGreaterThan(0)
+    expect(searchResults12.length).toBeGreaterThan(searchResults1.length)
+    expect(searchResults12.length).toBeGreaterThan(searchResults2.length)
+
+    expect(searchResults12).toHaveLength(searchResults21.length)
+    expect(searchResults12).toHaveLength(searchResults21Foobar.length)
+  })
+
+
+  test(`can search for exact phrases enclosing query in double quotes`, () => {
+    const dataKey = getRandomTextFieldDataKey(bulkExperiments)
+    const queryString1 = getRandomValueFromKeyedRows(bulkExperiments, dataKey)
+    const queryString2 = getRandomValueFromKeyedRows(bulkExperiments, dataKey)
+    const searchResults1 =
+      bulkExperiments.filter(bulkExperiment => search(bulkExperiment, dataKey, `"${queryString1}"`))
+    const searchResults2 =
+      bulkExperiments.filter(bulkExperiment => search(bulkExperiment, dataKey, `"${queryString2}"`))
+
+    const searchResults12 =
+      bulkExperiments.filter(bulkExperiment => search(bulkExperiment, dataKey, `"${queryString1} ${queryString2}"`))
+
+    expect(searchResults1.length).toBeGreaterThan(0)
+    expect(searchResults2.length).toBeGreaterThan(0)
+    expect(searchResults12).toHaveLength(0)
+  })
+})

--- a/packages/atlas-experiment-table/src/TableManager.js
+++ b/packages/atlas-experiment-table/src/TableManager.js
@@ -7,28 +7,20 @@ import TablePreamble from './TablePreamble'
 import TableContent from './TableContent'
 import TableFooter from './TableFooter'
 
-const capitalizeEachWord = str => str.replace(/\w+([\s-])*/g, _.capitalize)
+import search from './search'
 
-const deepIncludesCaseInsensitive = (object, keys, value) =>
-  _.chain(object)
-    .pick(keys)
-    .values()
-    .flatten()
-    .map(_.toString)
-    .map(_.toLower)
-    .some(valueToLower => valueToLower.includes(_.toString(value).toLowerCase()))
-    .value()
+const capitalizeEachWord = str => str.replace(/\w+([\s-])*/g, _.capitalize)
 
 const filterSortDataRows = (dataRows, filters, displayedKeys, searchAll, sortColumnDataKey, ascendingOrder) => {
   const filterSortedDataRows = _.chain(dataRows)
     .filter(
       // Keep the rows whose displayed columns match searchAll
-      dataRow => deepIncludesCaseInsensitive(dataRow, displayedKeys, searchAll)
+      dataRow => search(dataRow, displayedKeys, searchAll)
       // Keep the rows that have matching values defined in the filters (i.e. table headers and drop-downs)
       &&
       _.chain(filters)
         .keys()
-        .every(filterKey => deepIncludesCaseInsensitive(dataRow, filterKey, filters[filterKey]))
+        .every(filterKey => search(dataRow, filterKey, filters[filterKey]))
         .value())
     // Sort by sortColumnDataKey
     .sortBy(

--- a/packages/atlas-experiment-table/src/search.js
+++ b/packages/atlas-experiment-table/src/search.js
@@ -1,19 +1,32 @@
 import _ from 'lodash'
 
+// Don’t search for queries that are shorter than this
+const TOKEN_MIN_LENGTH = 3
+
 const fuzzyDeepContainsCaseInsensitive = (object, keys, value) => {
-  const words = _.chain(object)
-    .pick(keys)
-    .values()
-    .flatten()
-    .map(_.toString)
-    .map(_.toLower)
-    .map(phrase => _.split(phrase, /\s+/))
-    .flatten()
-    .value()
+  const words =
+    _.chain(object)
+      .pick(keys)
+      .values()
+      .flatten()
+      .map(_.toString)
+      .map(_.toLower)
+      .map(phrase => _.split(phrase, /\s+/))
+      .flatten()
+      .value()
 
-  const searchTokens = _.chain(value).toLower().split(/\s+/).reject(_.isEmpty).value()
+  const searchTokens =
+    _.chain(value)
+      .toLower()
+      .split(/\s+/)
+      .reject(_.isEmpty)
+      .filter(searchToken => searchToken.length >= TOKEN_MIN_LENGTH)
+      .value()
 
-  return searchTokens.length === 0 || _.intersection(searchTokens, words).length > 0
+  return (
+    searchTokens.length === 0 ||
+    searchTokens.some(searchToken => words.some(word => word.includes(searchToken)))
+  )
 }
 
 const exactDeepContainsCaseInsensitive = (object, keys, value) =>
@@ -35,3 +48,5 @@ export default (object, keys, value) => {
     return fuzzyDeepContainsCaseInsensitive(object, keys, trimmedValue)
   }
 }
+
+export { TOKEN_MIN_LENGTH }

--- a/packages/atlas-experiment-table/src/search.js
+++ b/packages/atlas-experiment-table/src/search.js
@@ -1,0 +1,37 @@
+import _ from 'lodash'
+
+const fuzzyDeepContainsCaseInsensitive = (object, keys, value) => {
+  const words = _.chain(object)
+    .pick(keys)
+    .values()
+    .flatten()
+    .map(_.toString)
+    .map(_.toLower)
+    .map(phrase => _.split(phrase, /\s+/))
+    .flatten()
+    .value()
+
+  const searchTokens = _.chain(value).toLower().split(/\s+/).reject(_.isEmpty).value()
+
+  return searchTokens.length === 0 || _.intersection(searchTokens, words).length > 0
+}
+
+const exactDeepContainsCaseInsensitive = (object, keys, value) =>
+  _.chain(object)
+    .pick(keys)
+    .values()
+    .flatten()
+    .map(_.toString)
+    .map(_.toLower)
+    .some(valueToLower => valueToLower.includes(_.toString(value).toLowerCase()))
+    .value()
+
+export default (object, keys, value) => {
+  const trimmedValue = value.trim()
+
+  if (trimmedValue.charAt(0) === `"` && trimmedValue.charAt(trimmedValue.length - 1) === `"`) {
+    return exactDeepContainsCaseInsensitive(object, keys, trimmedValue.substring(1, trimmedValue.length - 1))
+  } else {
+    return fuzzyDeepContainsCaseInsensitive(object, keys, trimmedValue)
+  }
+}


### PR DESCRIPTION
The way to fix this issue was to broaden the default search results so that it matches any of the typed words in any order. In this way *Canis familiaris* matches *Canis lupus familiaris*, and also *familiaris canis* or *canis foobar* would. I decided to add an exact search if the searched phrase is enclosed in double quotes after running a poll in our Slack workspace.