### PR TITLE
Scxa tsne plot/bugfix/172954811 export as image fails

### DIFF
--- a/packages/scxa-tsne-plot/html/Demo.js
+++ b/packages/scxa-tsne-plot/html/Demo.js
@@ -58,6 +58,21 @@ const experiment4 = {
   ]
 }
 
+//Image export fails for the large experiments
+// Number of cells: 32,369
+const experiment5 = {
+  accession: `E-HCAD-14`,
+  species: `Mus musculus`,
+  perplexities: [25],
+  ks: [11],
+  metadata: [
+    {
+      value: `lung`,
+      label: `Organism part`
+    }
+  ]
+}
+
 const experimentOmega = {
   accession: `E-HCAD-4`,
   species: `Homo sapiens`,
@@ -79,7 +94,7 @@ const experimentOmega = {
   ]
 }
 
-const { accession, perplexities, ks, metadata, species } = experimentOmega
+const { accession, perplexities, ks, metadata, species } = experiment5
 
 class Demo extends React.Component {
   constructor(props) {

--- a/packages/scxa-tsne-plot/src/plotloader/ScatterPlot.js
+++ b/packages/scxa-tsne-plot/src/plotloader/ScatterPlot.js
@@ -4,6 +4,7 @@ import Highcharts from 'highcharts'
 import HighchartsReact from 'highcharts-react-official'
 
 import HighchartsExporting from 'highcharts/modules/exporting'
+import HighchartsOfflineExporting from 'highcharts/modules/offline-exporting'
 import HighchartsColorAxis from 'highcharts/modules/coloraxis'
 
 //import HighchartsMap from 'highcharts/modules/map'
@@ -37,6 +38,7 @@ async function addModules() {
   // Only include modules if Highcharts isn’t a *good* mock -- Boost/Exporting can break tests
   // if (Highcharts.getOptions()) {...}
   HighchartsExporting(Highcharts)
+  HighchartsOfflineExporting(Highcharts)
   highchartsExportStyle(Highcharts)
 
   HighchartsColorAxis(Highcharts)


### PR DESCRIPTION
Bug: When user try to download large experiments in the single-cell atlas, high charts export server giving error `

> 413 Request Entity Too Large

As per @alfonsomunozpomer  - added 'offline-exporting' module and wrap that in the high charts module which we are already doing. 

I have followed this [JSFiddle](https://jsfiddle.net/gh/get/jquery/1.11.0/highslide-software/highcharts.com/tree/master/samples/highcharts/exporting/offline-download-demo/) to fix this
