### PR TITLE
📦 scxa-tsne-plot 💬 Bugfix #174357060 – Not Available points not visible

### DIFF
--- a/packages/scxa-tsne-plot/__test__/ClusterTSnePlot.test.js
+++ b/packages/scxa-tsne-plot/__test__/ClusterTSnePlot.test.js
@@ -42,13 +42,9 @@ describe(`ClusterTSnePlot colourize function`, () => {
     const randomSeries = randomHighchartsSeriesWithNamesAndMaxPoints([...seriesNames, `Not available`], maxPointsPerSeries)
     _colourizeClusters([], `lightgrey`)(randomSeries).forEach((series) => {
       if(series.name === `Not available`) {
-        series.data.forEach((point) => {
-          expect(point).toHaveProperty(`color`)
-        })
+        expect(series).toHaveProperty(`color`)
       } else {
-        series.data.forEach((point) => {
-          expect(point).not.toHaveProperty(`color`)
-        })
+        expect(series).not.toHaveProperty(`color`)
       }
     })
   })
@@ -57,7 +53,7 @@ describe(`ClusterTSnePlot colourize function`, () => {
     const randomSeries = randomHighchartsSeriesWithNamesAndMaxPoints(seriesNames, maxPointsPerSeries)
     _colourizeClusters([], `lightgrey`)(randomSeries).forEach((series) => {
       series.data.forEach((point) => {
-        expect(point).not.toHaveProperty(`color`)
+        expect(point).not.toHaveProperty(`color`,  Color(`lightgrey`).alpha(0.65).rgb().toString())
       })
     })
   })
@@ -77,9 +73,9 @@ describe(`ClusterTSnePlot colourize function`, () => {
     _colourizeClusters(highlightRandomSeries, `lightgrey`)(randomSeries).forEach((series) => {
       series.data.forEach((point) => {
         if (highlightRandomSeriesNames.includes(series.name)) {
-          expect(point).not.toHaveProperty(`color`)
+          expect(series).not.toHaveProperty(`color`)
         } else {
-          expect(point).toHaveProperty(`color`, Color(`lightgrey`).alpha(0.65).rgb().toString())
+          expect(series).toHaveProperty(`color`, Color(`lightgrey`).alpha(0.65).rgb().toString())
         }
       })
     })

--- a/packages/scxa-tsne-plot/html/Demo.js
+++ b/packages/scxa-tsne-plot/html/Demo.js
@@ -73,6 +73,21 @@ const experiment5 = {
   ]
 }
 
+//Image export fails for the large experiments
+// Number of cells: 32,369
+const experiment6 = {
+  accession: `E-CURD-46`,
+  species: `Homo sapiens`,
+  perplexities: [1, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50],
+  ks: [6, 9 , 11, 14, 17, 25, 32, 43, 55],
+  metadata: [
+    {
+      value: `authors_inferred_cell_type`,
+      label: `Authors Inferrede Cell type`
+    }
+  ]
+}
+
 const experimentOmega = {
   accession: `E-HCAD-4`,
   species: `Homo sapiens`,
@@ -94,7 +109,7 @@ const experimentOmega = {
   ]
 }
 
-const { accession, perplexities, ks, metadata, species } = experimentOmega
+const { accession, perplexities, ks, metadata, species } = experiment6
 
 class Demo extends React.Component {
   constructor(props) {

--- a/packages/scxa-tsne-plot/html/Demo.js
+++ b/packages/scxa-tsne-plot/html/Demo.js
@@ -73,8 +73,8 @@ const experiment5 = {
   ]
 }
 
-//Image export fails for the large experiments
-// Number of cells: 32,369
+// Big chunk of Not Available points
+// Number of cells: 101,843
 const experiment6 = {
   accession: `E-CURD-46`,
   species: `Homo sapiens`,
@@ -83,7 +83,7 @@ const experiment6 = {
   metadata: [
     {
       value: `authors_inferred_cell_type`,
-      label: `Authors Inferrede Cell type`
+      label: `Authors Inferred Cell Type`
     }
   ]
 }

--- a/packages/scxa-tsne-plot/package-lock.json
+++ b/packages/scxa-tsne-plot/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/scxa-tsne-plot",
-  "version": "5.2.0",
+  "version": "5.2.1-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/scxa-tsne-plot/package.json
+++ b/packages/scxa-tsne-plot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/scxa-tsne-plot",
-  "version": "5.2.0",
+  "version": "5.2.1-alpha.0",
   "description": "A twin plot of metadata and gene expression to display t-SNE plots in Single Cell Expression Atlas",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/scxa-tsne-plot/src/ClusterTSnePlot.js
+++ b/packages/scxa-tsne-plot/src/ClusterTSnePlot.js
@@ -14,10 +14,7 @@ const _colourizeClusters = (highlightSeries) =>
       if(aSeries.name === `Not available`) {
         return {
           name: aSeries.name,
-          data: aSeries.data.map((point) => ({
-            ...point,
-            color: Color(`lightgrey`).alpha(0.65).rgb().toString()
-          })),
+          data: aSeries.data,
           color: Color(`lightgrey`).alpha(0.65).rgb().toString()
         }
       } else return aSeries
@@ -25,10 +22,8 @@ const _colourizeClusters = (highlightSeries) =>
     } else {
       return {
         name: aSeries.name,
-        data: aSeries.data.map((point) => ({
-          ...point,
-          color: Color(`lightgrey`).alpha(0.65).rgb().toString()
-        }))
+        data: aSeries.data,
+        color: Color(`lightgrey`).alpha(0.65).rgb().toString()
       }
     }
   })

--- a/packages/scxa-tsne-widget/package-lock.json
+++ b/packages/scxa-tsne-widget/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ebi-gene-expression-group/scxa-tsne-widget",
-	"version": "2.2.0",
+	"version": "2.2.1-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/scxa-tsne-widget/package.json
+++ b/packages/scxa-tsne-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/scxa-tsne-widget",
-  "version": "2.2.0",
+  "version": "2.2.1-alpha.0",
   "description": "tSNE widget visualizes Single Cell Expression Atlas data",
   "main": "lib/index.js",
   "scripts": {
@@ -35,7 +35,7 @@
     "url": "git+https://github.com/ebi-gene-expression-group/atlas-components.git"
   },
   "dependencies": {
-    "@ebi-gene-expression-group/scxa-tsne-plot": "^5.2.0",
+    "@ebi-gene-expression-group/scxa-tsne-plot": "^5.2.1-alpha.0",
     "expression-atlas-autocomplete": "^3.2.0",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",


### PR DESCRIPTION
Adding both an single colour point and also a series colour (seemingly) made Not Available points invisible. It’s either an undefined behaviour in Highcharts or the opacity was reduced twice (set to 0.65 × 0.65). With the added inconvenience that it wasn’t consistent, so I suspect it’s the former.