### PR TITLE
📦 scxa-tsne-plot 💬 Bugfix #174786132 – 0 expression values breaks the plot when integrated in the experiment page

### DIFF
--- a/packages/scxa-tsne-plot/package-lock.json
+++ b/packages/scxa-tsne-plot/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/scxa-tsne-plot",
-  "version": "5.2.1",
+  "version": "5.3.0-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/scxa-tsne-plot/package.json
+++ b/packages/scxa-tsne-plot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/scxa-tsne-plot",
-  "version": "5.2.1",
+  "version": "5.3.0-alpha.0",
   "description": "A twin plot of metadata and gene expression to display t-SNE plots in Single Cell Expression Atlas",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/scxa-tsne-plot/src/plotloader/modules/coloraxis-logarithmic-with-negative-values.js
+++ b/packages/scxa-tsne-plot/src/plotloader/modules/coloraxis-logarithmic-with-negative-values.js
@@ -8,37 +8,37 @@
  */
 
 export default function (H) {
-    // Pass error messages
-    H.addEvent(H.ColorAxis, 'init', function (e) {
-        this.allowNegativeLog = e.userOptions.allowNegativeLog;
-    });
+  H.addEvent(H.Axis, 'afterInit', function () {
+    const logarithmic = this.logarithmic;
 
-    // Override conversions
-    H.wrap(H.ColorAxis.prototype, 'log2lin', function (proceed, num) {
-        if (!this.allowNegativeLog) {
-            return proceed.call(this, num);
-        }
+    if (logarithmic && this.options.allowNegativeLog) {
 
-        var isNegative = num < 0,
-            adjustedNum = Math.abs(num),
-            result;
+      // Avoid errors on negative numbers on a log axis
+      this.positiveValuesOnly = false;
+
+      // Override the converter functions
+      logarithmic.log2lin = num => {
+        const isNegative = num < 0;
+
+        let adjustedNum = Math.abs(num);
+
         if (adjustedNum < 10) {
-            adjustedNum += (10 - adjustedNum) / 10;
-        }
-        result = Math.log(adjustedNum) / Math.LN10;
-        return isNegative ? -result : result;
-    });
-    H.wrap(H.ColorAxis.prototype, 'lin2log', function (proceed, num) {
-        if (!this.allowNegativeLog) {
-            return proceed.call(this, num);
+          adjustedNum += (10 - adjustedNum) / 10;
         }
 
-        var isNegative = num < 0,
-            absNum = Math.abs(num),
-            result = Math.pow(10, absNum);
+        const result = Math.log(adjustedNum) / Math.LN10;
+        return isNegative ? -result : result;
+      };
+
+      logarithmic.lin2log = num => {
+        const isNegative = num < 0;
+
+        let result = Math.pow(10, Math.abs(num));
         if (result < 10) {
-            result = (10 * (result - 1)) / (10 - 1);
+          result = (10 * (result - 1)) / (10 - 1);
         }
         return isNegative ? -result : result;
-    });
+      };
+    }
+  });
 }

--- a/packages/scxa-tsne-widget/package-lock.json
+++ b/packages/scxa-tsne-widget/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ebi-gene-expression-group/scxa-tsne-widget",
-	"version": "2.2.1",
+	"version": "2.2.2-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/scxa-tsne-widget/package.json
+++ b/packages/scxa-tsne-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/scxa-tsne-widget",
-  "version": "2.2.1",
+  "version": "2.2.2-alpha.0",
   "description": "tSNE widget visualizes Single Cell Expression Atlas data",
   "main": "lib/index.js",
   "scripts": {
@@ -35,7 +35,7 @@
     "url": "git+https://github.com/ebi-gene-expression-group/atlas-components.git"
   },
   "dependencies": {
-    "@ebi-gene-expression-group/scxa-tsne-plot": "^5.2.1",
+    "@ebi-gene-expression-group/scxa-tsne-plot": "^5.3.0-alpha.0",
     "expression-atlas-autocomplete": "^3.2.0",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",


### PR DESCRIPTION
**Very annoyingly**, this doesn’t manifest in the `scxa-tsne-plot` package, only when it’s integrated in the experiment page. Very probably, something to do with how rendering and initialising the Highcharts object is handled. The fact that [the updated negative log fiddle](https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/coloraxis/logarithmic-with-emulate-negative-values/) changes the first event from `init` to `afterInit` reinforces my suspicion.