### PR TITLE
Select inferred cell type by default to color by if they exist

### DIFF
--- a/packages/scxa-tsne-plot/__test__/ClusterTSnePlot.test.js
+++ b/packages/scxa-tsne-plot/__test__/ClusterTSnePlot.test.js
@@ -94,6 +94,7 @@ describe(`ClusterTSnePlot`, () => {
     metadata: [],
     ks: [],
     perplexities: [],
+    initialCellTypeValues: [`inferred_cell_type_-_authors_labels`,`inferred_cell_type_-_ontology_labels`],
     loading: true
   }
 
@@ -154,6 +155,26 @@ describe(`ClusterTSnePlot`, () => {
     const dropdown = wrapper.find({ labelText: `Colour plot by:`})
 
     expect(dropdown.props().defaultValue.label).toContain(`The first metadata value`)
+  })
+
+  test(`dropdown selection text is inferred_cell_type when metadata options contain when plot is coloured by metadata`, () => {
+    const ks = [1, 2, 3]
+    const metadata = [
+      {
+        value: `metadata-1`,
+        label: `The first metadata value`
+      },
+      {
+        value: `inferred_cell_type_-_authors_labels`,
+        label: `Inferred cell type - authors_labels`
+      }
+    ]
+
+    const wrapper = mount(<ClusterTSnePlot {...props} ks={ks} metadata={metadata} selectedPerplexity={0} showControls={true}/>)
+
+    const dropdown = wrapper.find({ labelText: `Colour plot by:`})
+
+    expect(dropdown.props().defaultValue.label).toContain(`Inferred cell type - authors_labels`)
   })
 
   test(`hides the cluster name in tooltips if tSNE is coloured by metadata`, () => {

--- a/packages/scxa-tsne-plot/html/Demo.js
+++ b/packages/scxa-tsne-plot/html/Demo.js
@@ -24,8 +24,8 @@ const experiment2 = {
   ks: [8, 21, 43, 53, 63],
   metadata: [
     {
-      value: `characteristic_inferred_cell_type`,
-      label: `Inferred cell type`
+      value: `inferred_cell_type_-_ontology_labels`,
+      label: `Inferred cell type - ontology labels`
     }
   ]
 }
@@ -82,8 +82,8 @@ const experiment6 = {
   ks: [6, 9 , 11, 14, 17, 25, 32, 43, 55],
   metadata: [
     {
-      value: `authors_inferred_cell_type`,
-      label: `Authors Inferred Cell Type`
+      value: `inferred_cell_type_-_authors_labels`,
+      label: `Inferred cell type - authors labels`
     }
   ]
 }

--- a/packages/scxa-tsne-plot/src/ClusterTSnePlot.js
+++ b/packages/scxa-tsne-plot/src/ClusterTSnePlot.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Color from 'color'
-import {find as _find, flatten as _flatten} from 'lodash'
+import _ from 'lodash'
 
 import ScatterPlotLoader from './plotloader/PlotLoader'
 import PlotSettingsDropdown from './PlotSettingsDropdown'
@@ -37,7 +37,7 @@ const tooltipHeader = (clusterType, series, point) => {
 const ClusterTSnePlot = (props) => {
   const {ks, perplexities, metadata, selectedPerplexity, onChangePerplexity, selectedColourBy, onChangeColourBy, clusterType} = props  // Select
   const {plotData, highlightClusters, height, tooltipContent} = props   // Chart
-  const {loading, resourcesUrl, errorMessage, showControls} = props   // Overlay
+  const {loading, resourcesUrl, errorMessage, showControls, initialCellTypeValues} = props   // Overlay
   const opacity = 0.7
 
   const highchartsConfig = {
@@ -143,11 +143,13 @@ const ClusterTSnePlot = (props) => {
     },
   ]
 
-  const defaultValue = _find(
-    _flatten(
+  const cellType = _.first(_.intersection(_.map(metadataOptions,`value`),initialCellTypeValues))
+
+  const defaultValue = _.find(
+    _.flatten(
       options.map((item) => (item.options))
     ),
-    {value: selectedColourBy}
+    {value: cellType === undefined ? selectedColourBy : cellType}
   )
 
   const afterRender = (chart) => {
@@ -205,6 +207,7 @@ ClusterTSnePlot.propTypes = {
   plotData: PropTypes.shape({
     series: PropTypes.array.isRequired
   }),
+  initialCellTypeValues: PropTypes.array.isRequired,
   highlightClusters: PropTypes.array,
 
   ks: PropTypes.arrayOf(PropTypes.number).isRequired,

--- a/packages/scxa-tsne-plot/src/ClusterTSnePlot.js
+++ b/packages/scxa-tsne-plot/src/ClusterTSnePlot.js
@@ -143,13 +143,13 @@ const ClusterTSnePlot = (props) => {
     },
   ]
 
-  const cellType = _.first(_.intersection(_.map(metadataOptions,`value`),initialCellTypeValues))
+  const cellType = _.first(_.intersection(_.map(metadataOptions,`value`), initialCellTypeValues))
 
   const defaultValue = _.find(
     _.flatten(
       options.map((item) => (item.options))
     ),
-    {value: cellType === undefined ? selectedColourBy : cellType}
+    {value: cellType ? cellType : selectedColourBy}
   )
 
   const afterRender = (chart) => {

--- a/packages/scxa-tsne-plot/src/TSnePlotView.js
+++ b/packages/scxa-tsne-plot/src/TSnePlotView.js
@@ -93,7 +93,7 @@ class TSnePlotView extends React.Component {
   }
 
   render() {
-    const {height, atlasUrl, resourcesUrl, suggesterEndpoint, showControls} = this.props
+    const {height, atlasUrl, resourcesUrl, suggesterEndpoint, showControls, initialCellTypeValues} = this.props
     const {wrapperClassName, clusterPlotClassName, expressionPlotClassName} = this.props
     const {geneId, speciesName, geneIds} = this.props
     const highlightClusters = []
@@ -137,6 +137,7 @@ class TSnePlotView extends React.Component {
             tooltipContent={getTooltipContent}
             clusterType={selectedColourByCategory}
             showControls={showControls}
+            initialCellTypeValues={initialCellTypeValues}
           />
         </div>
 
@@ -194,6 +195,7 @@ TSnePlotView.propTypes = {
   speciesName: PropTypes.string.isRequired,
   height: PropTypes.number,
   resourcesUrl: PropTypes.string,
+  initialCellTypeValues: PropTypes.array,
   onSelectGeneId: PropTypes.func,
   onChangePerplexity: PropTypes.func
 }
@@ -207,6 +209,7 @@ TSnePlotView.defaultProps = {
   geneId: ``,
   speciesName: ``,
   height: 800,
+  initialCellTypeValues: [`inferred_cell_type_-_authors_labels`,`inferred_cell_type_-_ontology_labels`],
   onSelectGeneId: () => {},
   onChangeColourBy: () => {},
   onPerplexityChange: () => {}


### PR DESCRIPTION
I have added additional props in `TSnePlotView.js` to be a bit flexible in the sense if in future the values change so we can pass them as props from `jsp` rather than hardcoding. I have also added a test case to see if `inferred_cell_type` is selected by default if it exists. The details of the story are [here](https://www.pivotaltracker.com/story/show/174292400).