### PR TITLE
Divide perplexity dropdown to two dropdowns

### DIFF
--- a/packages/scxa-tsne-plot/__test__/ClusterTSnePlot.test.js
+++ b/packages/scxa-tsne-plot/__test__/ClusterTSnePlot.test.js
@@ -87,9 +87,23 @@ describe(`ClusterTSnePlot`, () => {
   const props = {
     onChangeColourBy: () => {},
     onChangePerplexity: () => {},
+    onChangePlotOptions: () => {},
+    onChangePlotTypes: () => {},
     plotData: {
       series: []
     },
+    plotTypeDropdown: [
+      {
+        plotType: `TSne`,
+        plotOptionsLabel: `Perplexities`,
+        plotOptions: [1, 2, 3, 4]
+      },
+      {
+        plotType: `UMap`,
+        plotOptionsLabel: `N-neighbors`,
+        plotOptions: [1, 2, 3]
+      }
+    ],
     height: 500,
     metadata: [],
     ks: [],
@@ -111,10 +125,10 @@ describe(`ClusterTSnePlot`, () => {
     expect(wrapper.find(ScatterPlotLoader).length).toBe(1)
   })
 
-  test(`contains 2 PlotSettingsDropdowns`, () => {
+  test(`contains 3 PlotSettingsDropdowns`, () => {
     const wrapper = mount(<ClusterTSnePlot {...props} selectedColourBy={`0`} selectedPerplexity={0} showControls={true}/>)
 
-    expect(wrapper.find(PlotSettingsDropdown).length).toBe(2)
+    expect(wrapper.find(PlotSettingsDropdown).length).toBe(3)
   })
 
   test(`contains only 1 PlotSettingsDropdowns when showControls is false`, () => {
@@ -157,8 +171,8 @@ describe(`ClusterTSnePlot`, () => {
   })
 
   test(`hides the cluster name in tooltips if tSNE is coloured by metadata`, () => {
-    const randomSeries1 = randomHighchartsSeriesWithNamesAndMaxPoints(seriesNames, 10).map(point => Object.assign(point, {clusterType: "clusters"}))
-    const randomSeries2 = randomHighchartsSeriesWithNamesAndMaxPoints(seriesNames, 10).map(point => Object.assign(point, {clusterType: "metadata"}))
+    const randomSeries1 = randomHighchartsSeriesWithNamesAndMaxPoints(seriesNames, 10).map(point => Object.assign(point, {clusterType: `clusters`}))
+    const randomSeries2 = randomHighchartsSeriesWithNamesAndMaxPoints(seriesNames, 10).map(point => Object.assign(point, {clusterType: `metadata`}))
     randomSeries1.forEach(point => expect(tooltipHeader(point.clusterType, point, point)).toContain(`Cluster name`))
     randomSeries2.forEach(point => expect(tooltipHeader(point.clusterType, point, point)).not.toContain(`Cluster name`))
   })

--- a/packages/scxa-tsne-plot/__test__/__snapshots__/ClusterTSnePlot.test.js.snap
+++ b/packages/scxa-tsne-plot/__test__/__snapshots__/ClusterTSnePlot.test.js.snap
@@ -9,7 +9,7 @@ Array [
       className="small-12 medium-6 columns"
     >
       <label>
-        t-SNE Perplexity
+        Plot Types
       </label>
       <div
         className=" css-2b097c-container"
@@ -26,7 +26,7 @@ Array [
             <div
               className=" css-1uccc91-singleValue"
             >
-              0
+              TSne
             </div>
             <div
               className="css-b8ldur-Input"
@@ -46,6 +46,94 @@ Array [
                   autoCorrect="off"
                   disabled={false}
                   id="react-select-2-input"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  spellCheck="false"
+                  style={
+                    Object {
+                      "background": 0,
+                      "border": 0,
+                      "boxSizing": "content-box",
+                      "color": "inherit",
+                      "fontSize": "inherit",
+                      "label": "input",
+                      "opacity": 1,
+                      "outline": 0,
+                      "padding": 0,
+                      "width": "1px",
+                    }
+                  }
+                  tabIndex="0"
+                  type="text"
+                  value=""
+                />
+                <div
+                  style={
+                    Object {
+                      "height": 0,
+                      "left": 0,
+                      "overflow": "scroll",
+                      "position": "absolute",
+                      "top": 0,
+                      "visibility": "hidden",
+                      "whiteSpace": "pre",
+                    }
+                  }
+                >
+                  
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className=" css-1hb7zxy-IndicatorsContainer"
+          >
+            <span
+              className="sc-AxirZ eHnaPO"
+              cx={[Function]}
+            />
+          </div>
+        </div>
+      </div>
+      <label>
+        Perplexities
+      </label>
+      <div
+        className=" css-2b097c-container"
+        onKeyDown={[Function]}
+      >
+        <div
+          className=" css-15r8ym2-Control"
+          onMouseDown={[Function]}
+          onTouchEnd={[Function]}
+        >
+          <div
+            className=" css-g1d714-ValueContainer"
+          >
+            <div
+              className=" css-1uccc91-singleValue"
+            >
+              1
+            </div>
+            <div
+              className="css-b8ldur-Input"
+            >
+              <div
+                className=""
+                style={
+                  Object {
+                    "display": "inline-block",
+                  }
+                }
+              >
+                <input
+                  aria-autocomplete="list"
+                  autoCapitalize="none"
+                  autoComplete="off"
+                  autoCorrect="off"
+                  disabled={false}
+                  id="react-select-3-input"
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
@@ -137,7 +225,7 @@ Array [
                   autoComplete="off"
                   autoCorrect="off"
                   disabled={false}
-                  id="react-select-3-input"
+                  id="react-select-4-input"
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}

--- a/packages/scxa-tsne-plot/html/Demo.js
+++ b/packages/scxa-tsne-plot/html/Demo.js
@@ -85,6 +85,18 @@ const experiment6 = {
       value: `authors_inferred_cell_type`,
       label: `Authors Inferred Cell Type`
     }
+  ],
+  plotTypeDropdown: [
+    {
+      plotType: `TSne`,
+      plotOptionsLabel: `Perplexities`,
+      plotOptions: [1, 2, 3, 4]
+    },
+    {
+      plotType: `UMap`,
+      plotOptionsLabel: `N-neighbors`,
+      plotOptions: [1, 2, 3]
+    }
   ]
 }
 
@@ -109,7 +121,7 @@ const experimentOmega = {
   ]
 }
 
-const { accession, perplexities, ks, metadata, species } = experiment6
+const { accession, perplexities, ks, metadata, species, plotTypeDropdown } = experiment6
 
 class Demo extends React.Component {
   constructor(props) {
@@ -172,6 +184,9 @@ class Demo extends React.Component {
           selectedPerplexity={this.state.perplexity}
           ks={ks}
           metadata={metadata}
+          plotTypeDropdown={plotTypeDropdown}
+          onChangePlotTypes={() => {}}
+          onChangePlotOptions={() => {}}
           selectedColourBy={this.state.selectedColourBy}
           selectedColourByCategory={this.state.selectedColourByCategory} // Is the plot coloured by clusters or metadata
           highlightClusters={this.state.highlightClusters}

--- a/packages/scxa-tsne-plot/src/ClusterTSnePlot.js
+++ b/packages/scxa-tsne-plot/src/ClusterTSnePlot.js
@@ -34,168 +34,215 @@ const tooltipHeader = (clusterType, series, point) => {
   return `<b>Cell ID:</b> ${point.name}<br>` + clusterName
 }
 
-const ClusterTSnePlot = (props) => {
-  const {ks, perplexities, metadata, selectedPerplexity, onChangePerplexity, selectedColourBy, onChangeColourBy, clusterType} = props  // Select
-  const {plotData, highlightClusters, height, tooltipContent} = props   // Chart
-  const {loading, resourcesUrl, errorMessage, showControls} = props   // Overlay
-  const opacity = 0.7
+class ClusterTSnePlot extends React.Component {
+  constructor(props) {
+    super(props)
 
-  const highchartsConfig = {
-    plotOptions: {
-      scatter: {
-        marker: {
-          symbol: `circle`
-        }
-      }
-    },
-    // Generated with http://tools.medialab.sciences-po.fr/iwanthue/
-    colors: [
-      `rgba(212, 137, 48, ${opacity})`,
-      `rgba(71, 193, 152, ${opacity})`,
-      `rgba(90, 147, 221, ${opacity})`,
-      `rgba(194, 73, 97, ${opacity})`,
-      `rgba(128, 177, 66, ${opacity})`,
-      `rgba(208, 76, 134, ${opacity})`,
-      `rgba(188, 176, 59, ${opacity})`,
-      `rgba(132, 43, 102, ${opacity})`,
-      `rgba(93, 188, 108, ${opacity})`,
-      `rgba(82, 45, 128, ${opacity})`,
-      `rgba(101, 133, 52, ${opacity})`,
-      `rgba(169, 107, 212, ${opacity})`,
-      `rgba(185, 140, 70, ${opacity})`,
-      `rgba(82, 88, 180, ${opacity})`,
-      `rgba(176, 73, 62, ${opacity})`,
-      `rgba(101, 127, 233, ${opacity})`,
-      `rgba(214, 126, 188, ${opacity})`,
-      `rgba(196, 86, 178, ${opacity})`,
-      `rgba(173, 131, 211, ${opacity})`,
-      `rgba(193, 84, 47, ${opacity})`
-    ],
-    chart: {
-      height: height
-    },
-    title: {
-      text: `Clusters`
-    },
-    legend: {
-      enabled: true,
-      align: `center`,
-      verticalAlign: `bottom`,
-      layout: `horizontal`,
-      itemMarginBottom: 20
-    },
-    tooltip: {
-      formatter: function (tooltip) {
-        // Trick Highcharts into thinking the point is in the bottom half of the chart, so that the tooltip
-        // is displayed below the point
-        this.point.negative = true
-        const text = `Loading metadata...`
-        const header = tooltipHeader(clusterType, this.series, this.point)
-        const addMetadataToTooltipText = async () => {
-          try {
-            const response = await tooltipContent(this.point.name)
-
-            const content = response.map((metadata) => {
-              return `<b>${metadata.displayName}:</b> ${metadata.value}`
-            })
-
-            tooltip.label.attr({
-              text: header + content.join(`<br>`)
-            })
-          } catch (e) {
-            tooltip.label.attr({
-              text: header
-            })
-          }
-        }
-
-        addMetadataToTooltipText()
-
-        return header + text
-      }
+    this.state = {
+      selectedPlotType: this.props.plotTypeDropdown[0].plotType,
+      plotOptions: this.props.plotTypeDropdown[0].plotOptions,
+      plotOptionsLabel: this.props.plotTypeDropdown[0].plotOptionsLabel
     }
+
+    this.updateSelectedPlotType = this.updateSelectedPlotType.bind(this)
   }
 
-  const perplexityOptions = perplexities.sort((a, b) => a - b).map((perplexity) => ({
-    value: perplexity,
-    label: perplexity
-  }))
+  updateSelectedPlotType(plotType)
+  {
+    let plot = _find(this.props.plotTypeDropdown, (plot) => {
+      return plot.plotType === plotType.value})
 
-  const kOptions = ks.sort((a, b) => a - b).map((k) => ({
-    value: k.toString(),
-    label: `k = ${k}`,
-    group: `clusters`
-  }))
-
-  const metadataOptions = metadata.map((metadata) => ({
-    ...metadata,
-    group: `metadata`
-  }))
-
-  const options = [
-    {
-      label: `Metadata`,
-      options: metadataOptions,
-    },
-    {
-      label: `Number of clusters`,
-      options: kOptions,
-    },
-  ]
-
-  const defaultValue = _find(
-    _flatten(
-      options.map((item) => (item.options))
-    ),
-    {value: selectedColourBy}
-  )
-
-  const afterRender = (chart) => {
-    chart.series.forEach(series => {
-      const legendSymbolSize = 10
-      series.legendSymbol.translate(
-        (series.legendSymbol.width / 2) - legendSymbolSize / 2,
-        (series.legendSymbol.height / 2) - legendSymbolSize / 2)
-      series.legendSymbol.attr(`width`, legendSymbolSize)
-      series.legendSymbol.attr(`height`, legendSymbolSize)
+    this.setState({
+      selectedPlotType: plotType.value,
+      plotOptions: plot.plotOptions,
+      plotOptionsLabel: plot.plotOptionsLabel
     })
   }
 
-  return [
-    <div key={`perplexity-k-select`} className={`row`}>
-      {showControls &&
-      <div className={`small-12 medium-6 columns`}>
-        <PlotSettingsDropdown
-          labelText={`t-SNE Perplexity`}
-          options={perplexityOptions}
-          defaultValue={{value: selectedPerplexity, label: selectedPerplexity}}
-          onSelect={(selectedOption) => {
-            onChangePerplexity(selectedOption.value)
-          }}/>
-      </div>
+  render() {
+    const {ks, metadata, selectedColourBy, onChangeColourBy, clusterType, onChangePlotOptions,
+      onChangePlotTypes, plotTypeDropdown} = this.props  // Select
+    const {plotData, highlightClusters, height, tooltipContent} = this.props   // Chart
+    const {loading, resourcesUrl, errorMessage, showControls} = this.props   // Overlay
+    const {selectedPlotType, plotOptions, plotOptionsLabel} = this.state
+    const opacity = 0.7
+
+    const highchartsConfig = {
+      plotOptions: {
+        scatter: {
+          marker: {
+            symbol: `circle`
+          }
+        }
+      },
+      // Generated with http://tools.medialab.sciences-po.fr/iwanthue/
+      colors: [
+        `rgba(212, 137, 48, ${opacity})`,
+        `rgba(71, 193, 152, ${opacity})`,
+        `rgba(90, 147, 221, ${opacity})`,
+        `rgba(194, 73, 97, ${opacity})`,
+        `rgba(128, 177, 66, ${opacity})`,
+        `rgba(208, 76, 134, ${opacity})`,
+        `rgba(188, 176, 59, ${opacity})`,
+        `rgba(132, 43, 102, ${opacity})`,
+        `rgba(93, 188, 108, ${opacity})`,
+        `rgba(82, 45, 128, ${opacity})`,
+        `rgba(101, 133, 52, ${opacity})`,
+        `rgba(169, 107, 212, ${opacity})`,
+        `rgba(185, 140, 70, ${opacity})`,
+        `rgba(82, 88, 180, ${opacity})`,
+        `rgba(176, 73, 62, ${opacity})`,
+        `rgba(101, 127, 233, ${opacity})`,
+        `rgba(214, 126, 188, ${opacity})`,
+        `rgba(196, 86, 178, ${opacity})`,
+        `rgba(173, 131, 211, ${opacity})`,
+        `rgba(193, 84, 47, ${opacity})`
+      ],
+      chart: {
+        height: height
+      },
+      title: {
+        text: `Clusters`
+      },
+      legend: {
+        enabled: true,
+        align: `center`,
+        verticalAlign: `bottom`,
+        layout: `horizontal`,
+        itemMarginBottom: 20
+      },
+      tooltip: {
+        formatter: function (tooltip) {
+          // Trick Highcharts into thinking the point is in the bottom half of the chart, so that the tooltip
+          // is displayed below the point
+          this.point.negative = true
+          const text = `Loading metadata...`
+          const header = tooltipHeader(clusterType, this.series, this.point)
+          const addMetadataToTooltipText = async () => {
+            try {
+              const response = await tooltipContent(this.point.name)
+
+              const content = response.map((metadata) => {
+                return `<b>${metadata.displayName}:</b> ${metadata.value}`
+              })
+
+              tooltip.label.attr({
+                text: header + content.join(`<br>`)
+              })
+            } catch (e) {
+              tooltip.label.attr({
+                text: header
+              })
+            }
+          }
+
+          addMetadataToTooltipText()
+
+          return header + text
+        }
       }
-      <div className={`small-12 medium-6 columns`}>
-        <PlotSettingsDropdown
-          labelText={`Colour plot by:`}
-          options={metadata ? options : kOptions} // Some experiments don't have metadata in Solr, although they should do. Leaving this check in for now so we don't break the entire experiment page.
-          defaultValue={defaultValue}
-          onSelect={(selectedOption) => {
-            onChangeColourBy(selectedOption.group, selectedOption.value)
-          }}/>
-      </div>
-    </div>,
-    <ScatterPlotLoader
-      key={`cluster-plot`}
-      wrapperClassName={`row`}
-      chartClassName={`small-12 columns`}
-      series={_colourizeClusters(highlightClusters)(plotData.series)}
-      highchartsConfig={highchartsConfig}
-      loading={loading}
-      resourcesUrl={resourcesUrl}
-      errorMessage={errorMessage}
-      afterRender={afterRender}
-    />
-  ]
+    }
+
+    const plotOptionsValues = this.state.plotOptions.map((value) => ({
+      value: value,
+      label: value
+    }))
+
+    const plotTypesOptions = plotTypeDropdown.map((plot) => ({
+      value: plot.plotType,
+      label: plot.plotType
+    }))
+
+    const kOptions = ks.sort((a, b) => a - b).map((k) => ({
+      value: k.toString(),
+      label: `k = ${k}`,
+      group: `clusters`
+    }))
+
+    const metadataOptions = metadata.map((metadata) => ({
+      ...metadata,
+      group: `metadata`
+    }))
+
+    const options = [
+      {
+        label: `Metadata`,
+        options: metadataOptions,
+      },
+      {
+        label: `Number of clusters`,
+        options: kOptions,
+      },
+    ]
+
+    const defaultValue = _find(
+      _flatten(
+        options.map((item) => (item.options))
+      ),
+      {value: selectedColourBy}
+    )
+
+    const afterRender = (chart) => {
+      chart.series.forEach(series => {
+        const legendSymbolSize = 10
+        series.legendSymbol.translate(
+          (series.legendSymbol.width / 2) - legendSymbolSize / 2,
+          (series.legendSymbol.height / 2) - legendSymbolSize / 2)
+        series.legendSymbol.attr(`width`, legendSymbolSize)
+        series.legendSymbol.attr(`height`, legendSymbolSize)
+      })
+    }
+
+
+
+    return (
+      <React.Fragment>
+        <div key={`perplexity-k-select`} className={`row`}>
+          {showControls &&
+        <div className={`small-12 medium-6 columns`}>
+          <PlotSettingsDropdown
+            labelText={`Plot Types`}
+            options={plotTypesOptions}
+            defaultValue={{value: selectedPlotType, label: selectedPlotType}}
+            onSelect={(selectedOption) => {
+              this.updateSelectedPlotType(selectedOption)
+              onChangePlotOptions(selectedOption.value)
+            }}/>
+          <PlotSettingsDropdown
+            labelText={plotOptionsLabel}
+            options={plotOptionsValues}
+            defaultValue={{value: plotOptions[0], label: plotOptions[0]}}
+            onSelect={(selectedOption) => {
+              onChangePlotTypes(selectedOption.value)
+            }}/>
+        </div>
+          }
+          <div className={`small-12 medium-6 columns`}>
+            <PlotSettingsDropdown
+              labelText={`Colour plot by:`}
+              options={metadata ? options : kOptions} // Some experiments don't have metadata in Solr, although they should do. Leaving this check in for now so we don't break the entire experiment page.
+              defaultValue={defaultValue}
+              onSelect={(selectedOption) => {
+                onChangeColourBy(selectedOption.group, selectedOption.value)
+              }}/>
+          </div>
+        </div>
+        <ScatterPlotLoader
+          key={`cluster-plot`}
+          wrapperClassName={`row`}
+          chartClassName={`small-12 columns`}
+          series={_colourizeClusters(highlightClusters)(plotData.series)}
+          highchartsConfig={highchartsConfig}
+          loading={loading}
+          resourcesUrl={resourcesUrl}
+          errorMessage={errorMessage}
+          afterRender={afterRender}
+        />
+      </React.Fragment>
+    )
+  }
+
+
 }
 
 ClusterTSnePlot.propTypes = {
@@ -220,11 +267,21 @@ ClusterTSnePlot.propTypes = {
   selectedPerplexity: PropTypes.number.isRequired,
   onChangePerplexity: PropTypes.func.isRequired,
 
+  onChangePlotOptions: PropTypes.func.isRequired,
+  onChangePlotTypes: PropTypes.func.isRequired,
+
   loading: PropTypes.bool.isRequired,
   resourcesUrl: PropTypes.string,
   errorMessage: PropTypes.string,
 
-  tooltipContent: PropTypes.func
+  tooltipContent: PropTypes.func,
+  plotTypeDropdown: PropTypes.arrayOf(
+    PropTypes.shape({
+      plotType: PropTypes.string,
+      plotOptionsLabel: PropTypes.string,
+      plotOptions: PropTypes.arrayOf(PropTypes.number)
+    })
+  )
 }
 
 export {ClusterTSnePlot as default, _colourizeClusters, tooltipHeader}

--- a/packages/scxa-tsne-plot/src/TSnePlotView.js
+++ b/packages/scxa-tsne-plot/src/TSnePlotView.js
@@ -97,8 +97,8 @@ class TSnePlotView extends React.Component {
     const {wrapperClassName, clusterPlotClassName, expressionPlotClassName} = this.props
     const {geneId, speciesName, geneIds} = this.props
     const highlightClusters = []
-    const {ks, perplexities, selectedPerplexity, metadata, selectedColourBy, selectedColourByCategory} = this.props
-    const {onChangePerplexity, onSelectGeneId, onChangeColourBy} = this.props
+    const {ks, perplexities, selectedPerplexity, metadata, selectedColourBy, selectedColourByCategory, plotTypeDropdown} = this.props
+    const {onChangePerplexity, onSelectGeneId, onChangeColourBy, onChangePlotOptions, onChangePlotTypes} = this.props
     const {loadingGeneExpression, geneExpressionData, geneExpressionErrorMessage} = this.state
     const {loadingCellClusters, cellClustersData, cellClustersErrorMessage} = this.state
 
@@ -126,6 +126,9 @@ class TSnePlotView extends React.Component {
             perplexities={perplexities}
             selectedPerplexity={selectedPerplexity}
             onChangePerplexity={onChangePerplexity}
+            onChangePlotOptions={onChangePlotOptions}
+            onChangePlotTypes={onChangePlotTypes}
+            plotTypeDropdown={plotTypeDropdown}
             ks={ks}
             metadata={metadata}
             onChangeColourBy={onChangeColourBy}
@@ -195,7 +198,16 @@ TSnePlotView.propTypes = {
   height: PropTypes.number,
   resourcesUrl: PropTypes.string,
   onSelectGeneId: PropTypes.func,
-  onChangePerplexity: PropTypes.func
+  onChangePerplexity: PropTypes.func,
+  onChangePlotOptions: PropTypes.func,
+  onChangePlotTypes: PropTypes.func,
+  plotTypeDropdown: PropTypes.arrayOf(
+    PropTypes.shape({
+      plotType: PropTypes.string,
+      plotOptionsLabel: PropTypes.string,
+      plotOptions: PropTypes.arrayOf(PropTypes.number)
+    })
+  )
 }
 
 TSnePlotView.defaultProps = {


### PR DESCRIPTION
The task is related to this [pivotal story](https://www.pivotaltracker.com/story/show/177160800). For this task I'm using the approach where the details regarding these two new dropdowns will be passed as props in the following data structure:

> plotTypeDropdown: [
    {
      plotType: `TSne`,
      plotOptionsLabel: `Perplexities`,
      plotOptions: [1, 2, 3, 4]
    },
    {
      plotType: `UMap`,
      plotOptionsLabel: `N-neighbors`,
      plotOptions: [1, 2, 3]
    }
  ]

The new prop name is `plotTypeDropdown` which is an array of objects each of which contains:

- Type of the plot
- Label to display over dropdown
- And the options to be displayed in the dropdown

The flexibility of such a data structure allows us to add more types of dropdowns in the future without changing any front-end code .