### PR TITLE
Re-render the component based on prop change

### DIFF
--- a/packages/atlas-experiment-table/__test__/TableManager.test.js
+++ b/packages/atlas-experiment-table/__test__/TableManager.test.js
@@ -184,6 +184,21 @@ describe(`TableManager`, () => {
     expect(wrapper.find(TableContent).prop(`dataRows`)).toHaveLength(0)
   })
 
+  test(`props change call ComponentDidUpdate function`, () => {
+    const wrapper =
+        shallow(
+            <TableManager
+                {...props}
+                dataRows={bulkExperiments}
+                tableHeaders={bulkTableHeaders}
+                dropdownFilters={bulkDropdownFilters}/>)
+
+    wrapper.setProps({dataRows: singleCellExperiments})
+    // logic to test here is once ComponentDidUpdate is called it will update state variable `filteredSortedDataRows`
+    // according to the new props which has been set in previous step
+    expect(wrapper.state(`filteredSortedDataRows`)).toHaveLength(wrapper.instance().props.dataRows.length)
+  })
+
   test(`can filter using a randomly picked searchable header, filtering is debounced 600ms (results found)`, (done) => {
     const wrapper =
       shallow(

--- a/packages/atlas-experiment-table/src/TableManager.js
+++ b/packages/atlas-experiment-table/src/TableManager.js
@@ -102,7 +102,8 @@ export default class TableManager extends React.Component {
       ,
       searchAll: ``,
       filters: filters,
-      selectedRows: []
+      selectedRows: [],
+      filteredSortedDataRows: []
     }
 
     const doFilterAndSort = () =>
@@ -196,6 +197,22 @@ export default class TableManager extends React.Component {
       },
       () => this.immediateFilterAndSort()
     )
+  }
+
+  componentDidUpdate(previousProps) {
+    if (previousProps.dataRows !== this.props.dataRows) {
+      this.setState(
+          {
+            filteredSortedDataRows: filterSortDataRows(
+                this.props.dataRows,
+                this.state.filters,
+                this.props.tableHeaders.map(tableHeader => tableHeader.dataKey),
+                this.state.searchAll,
+                this.props.tableHeaders.length > 0 ? this.props.tableHeaders[this.state.sortColumnIndex].dataKey : ``,
+                this.state.ascendingOrder)
+          }
+      )
+    }
   }
 
   render() {


### PR DESCRIPTION
We had an issue while integrating Anatomograms and Experiment Table when a prop change was triggered by Anatomogram filtering. The prop change did not re-render the experiment table as there was no state change in the component. To fix this issue, I have implemented the componentDidUpdate function of React component lifecycle.