### PR TITLE
📦 Atlas React Fetch Loader – 💬 Add ability to fetch raw text

### DIFF
--- a/packages/atlas-react-fetch-loader/README.md
+++ b/packages/atlas-react-fetch-loader/README.md
@@ -56,3 +56,29 @@ Besides the new props coming from the `fetch` request, you can add a `fulfilledP
 the payload as an argument and returns an object which, again, is destructured and added as props to the wrapped
 component. Additionally, you can rename fields from the JSON object with the `renameDataKeys` prop: any key is renamed
 to the string value.
+
+### Raw text
+By default the component will parse the response as JSON but a boolean prop `raw` can be set to `true`, in which case 
+the payload will be parsed as plain text. In this case `renameDataKeys` will be ignored but you can use the 
+`fulfilledPayloadProvider` to store the response in a prop of your choice for the wrapped component.
+
+A real use case is the Single Cell Expression Atlas Information Banner:
+```javascript
+import { withFetchLoader } from '@ebi-gene-expression-group/atlas-react-fetch-loader'
+import AtlasInformationBanner from '@ebi-gene-expression-group/atlas-information-banner'
+
+const AtlasInformationBannerWithFetchLoader = withFetchLoader(AtlasInformationBanner)
+const render = (options, target) => {
+    ReactDOM.render(
+      <AtlasInformationBannerWithFetchLoader
+        {...options}
+        host={`https://ebi-gene-expression-group.github.io/`}
+        resource={`scxa-motd.md`}
+        errorPayloadProvider={ () => {} }
+        loadingPayloadProvider={ () => {} }
+        fulfilledPayloadProvider={ data => ({ motd: data }) }
+        raw={true}
+      />,
+      document.getElementById(target))
+}
+```

--- a/packages/atlas-react-fetch-loader/__test__/FetchLoader.test.js
+++ b/packages/atlas-react-fetch-loader/__test__/FetchLoader.test.js
@@ -171,6 +171,24 @@ describe(`FetchLoader`, () => {
     expect(wrapper.find(MyComponent)).toHaveProp(`resultsLength`, payload.results.length)
   })
 
+  test(`can fetch raw text data and assign it to a prop`, async () => {
+    const markdownPayload = [
+      `**Help us improve Single Cell Expression Atlas**`,
+      ``,
+      `We are continuously developing the resource to deliver the best possible service for the community;`,
+      `Please take two minutes to fill out our user survey and help us make Expression Atlas even better.`,
+      ``,
+      `<a target={_blank} href="https://www.surveymonkey.co.uk/r/SCEAsurvey22" class="button">Take survey</a>`
+    ].join(`\n`)
+
+    fetchMock.get(`/foo/bar`, markdownPayload)
+    const wrapper = shallow(<ComponentWithFetchLoader {...props} raw={true} fulfilledPayloadProvider={ data => ({ motd: data }) }/>)
+
+    await wrapper.instance().componentDidMount()
+    expect(wrapper).toHaveState(`data`, markdownPayload)
+    expect(wrapper.find(MyComponent)).toHaveProp(`motd`, markdownPayload)
+  })
+
   test(`when host/resource change, the component is reset and reloads`, async () => {
     const firstPayload = {
       results: [{ title: `Foobar` }]

--- a/packages/atlas-react-fetch-loader/package.json
+++ b/packages/atlas-react-fetch-loader/package.json
@@ -1,12 +1,10 @@
 {
   "name": "@ebi-gene-expression-group/atlas-react-fetch-loader",
-  "version": "3.7.0",
+  "version": "3.8.0-beta1",
   "description": "A HOC React component that enables other components to remotely fetch data from an endpoint",
   "main": "lib/index.js",
   "scripts": {
-    "prepare": "rm -rf lib && babel src -d lib --copy-files",
-    "test": "jest",
-    "posttest": "jest --coverage --coverageReporters=text-lcov | coveralls"
+    "prepare": "rm -rf lib && babel src -d lib --copy-files"
   },
   "jest": {
     "setupFilesAfterEnv": [

--- a/packages/atlas-react-fetch-loader/src/FetchLoader.js
+++ b/packages/atlas-react-fetch-loader/src/FetchLoader.js
@@ -66,16 +66,19 @@ const withFetchLoader = (WrappedComponent) => {
           throw new Error(`${url} => ${response.status}`)
         }
 
-        const data = await response.json()
-        Object.keys(this.props.renameDataKeys)
-          .forEach(key => {
-            // Defend against accidental same-value fields: { foo: "foo" }
-            if (data[key]) {
-              const dataKey = data[key]
-              delete data[key]
-              Object.assign(data, {[this.props.renameDataKeys[key]]: dataKey })
-            }
-          })
+        const data = this.props.raw ? await response.text() : await response.json()
+
+        if (!this.props.raw) {
+          Object.keys(this.props.renameDataKeys)
+            .forEach(key => {
+              // Defend against accidental same-value fields: { foo: "foo" }
+              if (data[key]) {
+                const dataKey = data[key]
+                delete data[key]
+                Object.assign(data, {[this.props.renameDataKeys[key]]: dataKey })
+              }
+            })
+        }
 
         this.setState({
           data: data,
@@ -130,14 +133,16 @@ const withFetchLoader = (WrappedComponent) => {
     loadingPayloadProvider: PropTypes.func,
     errorPayloadProvider: PropTypes.func,
     fulfilledPayloadProvider: PropTypes.func,
-    renameDataKeys: PropTypes.objectOf(PropTypes.string)
+    renameDataKeys: PropTypes.objectOf(PropTypes.string),
+    raw: PropTypes.bool
   }
 
   FetchLoader.defaultProps = {
     loadingPayloadProvider: null,
     errorPayloadProvider: null,
     fulfilledPayloadProvider: () => {},
-    renameDataKeys: {}
+    renameDataKeys: {},
+    raw: false
   }
 
   return FetchLoader


### PR DESCRIPTION
Add optional raw prop to unpack the response as text (defaults to `false`). We want this so that we can combine it with the [latest iteration of the information banner](https://github.com/ebi-gene-expression-group/atlas-components/pull/101) and fetch a Markdown file from a URL and display it.