### PR TITLE
:package: atlas-react-fetch-loader :speech_balloon: Feature – Support query request parameters

### DIFF
--- a/packages/atlas-react-fetch-loader/package.json
+++ b/packages/atlas-react-fetch-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/atlas-react-fetch-loader",
-  "version": "3.8.0",
+  "version": "3.9.0-beta1",
   "description": "A HOC React component that enables other components to remotely fetch data from an endpoint",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/atlas-react-fetch-loader/src/FetchLoader.js
+++ b/packages/atlas-react-fetch-loader/src/FetchLoader.js
@@ -32,7 +32,7 @@ const withFetchLoader = (WrappedComponent) => {
     }
 
     static getDerivedStateFromProps(props, state) {
-      const url = URI(props.resource, props.host).toString()
+      const url = URI(props.resource, props.host).query(props.query).toString()
       // Store URL in state so we can compare when props change.
       // Clear out previously-loaded data (so we don't render stale stuff).
       if (url !== state.url) {
@@ -50,12 +50,12 @@ const withFetchLoader = (WrappedComponent) => {
 
     async componentDidUpdate(/*prevProps, prevState*/) {
       if (this.state.data === null && this.state.error === null) {
-        await this._loadAsyncData(URI(this.props.resource, this.props.host).toString())
+        await this._loadAsyncData(URI(this.props.resource, this.props.host).query(this.props.query).toString())
       }
     }
 
     async componentDidMount() {
-      await this._loadAsyncData(URI(this.props.resource, this.props.host).toString())
+      await this._loadAsyncData(URI(this.props.resource, this.props.host).query(this.props.query).toString())
     }
 
     async _loadAsyncData(url) {
@@ -130,6 +130,7 @@ const withFetchLoader = (WrappedComponent) => {
   FetchLoader.propTypes = {
     host: PropTypes.string.isRequired,
     resource: PropTypes.string.isRequired,
+    query: PropTypes.object,
     loadingPayloadProvider: PropTypes.func,
     errorPayloadProvider: PropTypes.func,
     fulfilledPayloadProvider: PropTypes.func,
@@ -138,6 +139,7 @@ const withFetchLoader = (WrappedComponent) => {
   }
 
   FetchLoader.defaultProps = {
+    query: {},
     loadingPayloadProvider: null,
     errorPayloadProvider: null,
     fulfilledPayloadProvider: () => {},


### PR DESCRIPTION
Add a prop to support query parameters (e.g. `?foo=bar`) in requests. The prop is an object that [can be parsed by URI.js as-is](https://medialize.github.io/URI.js/docs.html#accessors-search).