### PR TITLE
:package: atlas-react-fetch-loader :speech_balloon: Feature #179948196 – Support query request parameters

### DIFF
--- a/packages/atlas-react-fetch-loader/README.md
+++ b/packages/atlas-react-fetch-loader/README.md
@@ -14,6 +14,7 @@ ReactDOM.render(
   <MyComponentWithFetchLoader
     host={`https://domain.tld/path/`}
     resource={`json/endpoint`}
+    query={ {foo: [`qwerty`, `asdf`], bar: 42 } /* Will be parsed as ?foobar=qwerty&foobar=asdf&bar=42 */ }
     errorPayloadProvider={ error => /* some object with error info for the wrapped component */ }
     loadingPayloadProvider={ data => /* some object to display feedback while the component is loading */ }
     fulfilledPayloadProvider={ data => /* some object that is added as props */ }
@@ -58,8 +59,8 @@ component. Additionally, you can rename fields from the JSON object with the `re
 to the string value.
 
 ### Raw text
-By default the component will parse the response as JSON but a boolean prop `raw` can be set to `true`, in which case 
-the payload will be parsed as plain text. In this case `renameDataKeys` will be ignored but you can use the 
+The component will parse the response as JSON but a boolean prop `raw` can be set to `true`, in which case the payload
+will be parsed as plain text. In this case `renameDataKeys` will be ignored, but you can use the 
 `fulfilledPayloadProvider` to store the response in a prop of your choice for the wrapped component.
 
 A real use case is the Single Cell Expression Atlas Information Banner:

--- a/packages/atlas-react-fetch-loader/package.json
+++ b/packages/atlas-react-fetch-loader/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ebi-gene-expression-group/atlas-react-fetch-loader",
   "version": "3.9.0-beta1",
-  "description": "A HOC React component that enables other components to remotely fetch data from an endpoint",
+  "description": "A React HOC that enables other components to remotely fetch data from an endpoint",
   "main": "lib/index.js",
   "scripts": {
     "prepare": "rm -rf lib && babel src -d lib --copy-files"

--- a/packages/atlas-react-fetch-loader/package.json
+++ b/packages/atlas-react-fetch-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/atlas-react-fetch-loader",
-  "version": "3.8.0",
+  "version": "3.9.0-beta1",
   "description": "A HOC React component that enables other components to remotely fetch data from an endpoint",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/atlas-react-fetch-loader/src/FetchLoader.js
+++ b/packages/atlas-react-fetch-loader/src/FetchLoader.js
@@ -32,7 +32,7 @@ const withFetchLoader = (WrappedComponent) => {
     }
 
     static getDerivedStateFromProps(props, state) {
-      const url = URI(props.resource, props.host).toString()
+      const url = URI(props.resource, props.host).query(props.query).toString()
       // Store URL in state so we can compare when props change.
       // Clear out previously-loaded data (so we don't render stale stuff).
       if (url !== state.url) {
@@ -50,12 +50,12 @@ const withFetchLoader = (WrappedComponent) => {
 
     async componentDidUpdate(/*prevProps, prevState*/) {
       if (this.state.data === null && this.state.error === null) {
-        await this._loadAsyncData(URI(this.props.resource, this.props.host).toString())
+        await this._loadAsyncData(URI(this.props.resource, this.props.host).query(this.props.query).toString())
       }
     }
 
     async componentDidMount() {
-      await this._loadAsyncData(URI(this.props.resource, this.props.host).toString())
+      await this._loadAsyncData(URI(this.props.resource, this.props.host).query(this.props.query).toString())
     }
 
     async _loadAsyncData(url) {
@@ -130,6 +130,7 @@ const withFetchLoader = (WrappedComponent) => {
   FetchLoader.propTypes = {
     host: PropTypes.string.isRequired,
     resource: PropTypes.string.isRequired,
+    query: PropTypes.object,
     loadingPayloadProvider: PropTypes.func,
     errorPayloadProvider: PropTypes.func,
     fulfilledPayloadProvider: PropTypes.func,
@@ -138,6 +139,7 @@ const withFetchLoader = (WrappedComponent) => {
   }
 
   FetchLoader.defaultProps = {
+    query: {},
     loadingPayloadProvider: null,
     errorPayloadProvider: null,
     fulfilledPayloadProvider: () => {},


### PR DESCRIPTION
Add a prop to support query parameters (e.g. `?foo=bar`) in requests. The prop is an object that [can be parsed by URI.js as-is](https://medialize.github.io/URI.js/docs.html#accessors-search).