### PR TITLE
📦 scxa-tsne-plot 💬 Feature #181139004 – Move back 'Not available' metadata categories

### DIFF
--- a/packages/scxa-tsne-plot/__test__/ClusterTSnePlot.test.js
+++ b/packages/scxa-tsne-plot/__test__/ClusterTSnePlot.test.js
@@ -53,7 +53,7 @@ describe(`ClusterTSnePlot colourize function`, () => {
     const randomSeries = randomHighchartsSeriesWithNamesAndMaxPoints([...seriesNames, `Not available`], maxPointsPerSeries)
     _colourizeClusters([], `lightgrey`)(randomSeries).forEach((series) => {
       if(series.name === `Not available`) {
-        expect(series).toHaveProperty(`zIndex`)
+        expect(series).toHaveProperty(`zIndex`, -1)
       } else {
         expect(series).not.toHaveProperty(`zIndex`)
       }

--- a/packages/scxa-tsne-plot/__test__/ClusterTSnePlot.test.js
+++ b/packages/scxa-tsne-plot/__test__/ClusterTSnePlot.test.js
@@ -49,6 +49,17 @@ describe(`ClusterTSnePlot colourize function`, () => {
     })
   })
 
+  test(`must move behind if metadata is Not Available`, () => {
+    const randomSeries = randomHighchartsSeriesWithNamesAndMaxPoints([...seriesNames, `Not available`], maxPointsPerSeries)
+    _colourizeClusters([], `lightgrey`)(randomSeries).forEach((series) => {
+      if(series.name === `Not available`) {
+        expect(series).toHaveProperty(`zIndex`)
+      } else {
+        expect(series).not.toHaveProperty(`zIndex`)
+      }
+    })
+  })
+
   test(`must not dim (i.e. add a color field) any series if none are passed to highlight`, () => {
     const randomSeries = randomHighchartsSeriesWithNamesAndMaxPoints(seriesNames, maxPointsPerSeries)
     _colourizeClusters([], `lightgrey`)(randomSeries).forEach((series) => {

--- a/packages/scxa-tsne-plot/src/ClusterTSnePlot.js
+++ b/packages/scxa-tsne-plot/src/ClusterTSnePlot.js
@@ -24,7 +24,6 @@ const _colourizeClusters = (highlightSeries) =>
       return {
         name: aSeries.name,
         data: aSeries.data,
-        zIndex: 1,
         color: Color(`lightgrey`).alpha(0.65).rgb().toString()
       }
     }

--- a/packages/scxa-tsne-plot/src/ClusterTSnePlot.js
+++ b/packages/scxa-tsne-plot/src/ClusterTSnePlot.js
@@ -15,6 +15,7 @@ const _colourizeClusters = (highlightSeries) =>
         return {
           name: aSeries.name,
           data: aSeries.data,
+          zIndex: -1,
           color: Color(`lightgrey`).alpha(0.65).rgb().toString()
         }
       } else return aSeries
@@ -23,6 +24,7 @@ const _colourizeClusters = (highlightSeries) =>
       return {
         name: aSeries.name,
         data: aSeries.data,
+        zIndex: 1,
         color: Color(`lightgrey`).alpha(0.65).rgb().toString()
       }
     }


### PR DESCRIPTION
Massive `Not available` points will block other categories like below:
<img width="1440" alt="Screenshot 2022-06-08 at 06 58 04" src="https://user-images.githubusercontent.com/33519183/172547961-584db0c7-0416-49ab-9e47-d2bdac734694.png">

I added a z-index for each data series and make sure `Not available` is a negative and solve the issue:
<img width="1440" alt="Screenshot 2022-06-08 at 07 26 17" src="https://user-images.githubusercontent.com/33519183/172547970-db78c01a-6556-4800-8540-c6c364c6d023.png">

