### PR TITLE
:package: scxa-marker-gene-heatmap :speech_balloon: Feature #179976357-#182401310 – Replace “marker genes” with “top” genes in multiexperiment cell type heatmap

### DIFF
--- a/packages/scxa-marker-gene-heatmap/src/heatmapOptionsProvider.js
+++ b/packages/scxa-marker-gene-heatmap/src/heatmapOptionsProvider.js
@@ -16,9 +16,9 @@ const heatmapOptionsProvider = {
         }
       }
     },
-    title: cellType => `${cellType} marker genes`,
+    title: cellType => `${cellType}<br>top genes`,
     labelsFormatter: label => label,
-    noData: `No marker genes found for the selected cell type. Try selecting a different cell type.`
+    noData: `No high-scoring genes found for the selected cell type.`
   },
 
   celltypes: {
@@ -39,7 +39,7 @@ const heatmapOptionsProvider = {
         }
       }
     },
-    title: cellType => `${cellType} marker genes`,
+    title: cellType => `${cellType}<br>marker genes`,
     labelsFormatter: label => label,
     noData: `No marker genes found for the selected organ or region. Try selecting another organism part.`
   },


### PR DESCRIPTION


Fixes https://github.com/ebi-gene-expression-group/atlas-web-single-cell/issues/248.