### PR TITLE
Fix cell type data label not showing & add a test

### DIFF
--- a/packages/scxa-cell-type-wheel/cypress/component/CellTypeWheel.cy.js
+++ b/packages/scxa-cell-type-wheel/cypress/component/CellTypeWheel.cy.js
@@ -2,7 +2,9 @@ import React from 'react'
 import CellTypeWheel from '../../src/CellTypeWheel'
 
 import cellTypeWheelData from '../fixtures/lung-cancer.json'
-import bigCellTypeWheelData from '../fixtures/cancer.json'
+// cell type wheel data labels not showing properly with the cancer json response on Mac
+// a github issue is reported in highcharts repo: https://github.com/highcharts/highcharts/issues/18332
+import cancerCellTypeWheelData from '../fixtures/cancer.json'
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random
 function getRandomInt(max) {
@@ -91,17 +93,17 @@ describe(`<CellTypeWheel>`, () => {
     cy.get(`@onCellTypeWheelClick`).should(`not.have.been.called`)
   })
 
-  it(`should show data labels properly while zooming in from an inner cell`, () => {
+  it(`should show data labels properly after clicking on a species/organism part and zooming in`, () => {
     const callbackWrapper = {
       onCellTypeWheelClick: function (cellType, species, experimentAccessions) {
       }
     }
     cy.mount(
         <CellTypeWheel
-            data={bigCellTypeWheelData}
+            data={cancerCellTypeWheelData}
             onCellTypeWheelClick={callbackWrapper.onCellTypeWheelClick}
         />)
-    let innerRingElement = cy.contains(`Homo sapiens`)
+    const innerRingElement = cy.contains(`Homo sapiens`)
     innerRingElement.click({ force: true })
     const ringElement = cy.contains(`brain`)
     ringElement.click({ force: true })

--- a/packages/scxa-cell-type-wheel/cypress/component/CellTypeWheel.cy.js
+++ b/packages/scxa-cell-type-wheel/cypress/component/CellTypeWheel.cy.js
@@ -2,6 +2,7 @@ import React from 'react'
 import CellTypeWheel from '../../src/CellTypeWheel'
 
 import cellTypeWheelData from '../fixtures/lung-cancer.json'
+import bigCellTypeWheelData from '../fixtures/cancer.json'
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random
 function getRandomInt(max) {
@@ -88,5 +89,27 @@ describe(`<CellTypeWheel>`, () => {
     outerRingTextPath.click()
 
     cy.get(`@onCellTypeWheelClick`).should(`not.have.been.called`)
+  })
+
+  it(`should show data labels properly while zooming in from an inner cell`, () => {
+    const callbackWrapper = {
+      onCellTypeWheelClick: function (cellType, species, experimentAccessions) {
+      }
+    }
+    cy.mount(
+        <CellTypeWheel
+            data={bigCellTypeWheelData}
+            onCellTypeWheelClick={callbackWrapper.onCellTypeWheelClick}
+        />)
+    let innerRingElement = cy.contains(`Homo sapiens`)
+    innerRingElement.click({ force: true })
+    const ringElement = cy.contains(`brain`)
+    ringElement.click({ force: true })
+    cy.contains(`astrocyte`)
+
+    cy.get(`.highcharts-data-labels`).find(`text`).each(label =>
+        cy.get(label[0].attributes.visibility).should(`not.exist`)
+    )
+
   })
 })

--- a/packages/scxa-cell-type-wheel/cypress/fixtures/cancer.json
+++ b/packages/scxa-cell-type-wheel/cypress/fixtures/cancer.json
@@ -1,0 +1,2279 @@
+[
+  {
+    "name": "cancer",
+    "id": "cancer",
+    "parent": "",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-6308",
+      "E-CURD-95",
+      "E-CURD-11",
+      "E-GEOD-139324",
+      "E-GEOD-125970",
+      "E-CURD-97",
+      "E-MTAB-6075",
+      "E-GEOD-75367",
+      "E-MTAB-9435",
+      "E-GEOD-84465",
+      "E-MTAB-10290",
+      "E-MTAB-8559",
+      "E-MTAB-8410",
+      "E-GEOD-135922",
+      "E-GEOD-76312",
+      "E-CURD-6",
+      "E-GEOD-110499",
+      "E-GEOD-99795",
+      "E-MTAB-7249",
+      "E-MTAB-6487",
+      "E-CURD-96",
+      "E-EHCA-2",
+      "E-MTAB-5530"
+    ]
+  },
+  {
+    "name": "Danio rerio",
+    "id": "Danio rerio",
+    "parent": "cancer",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-5530"
+    ]
+  },
+  {
+    "name": "head kidney",
+    "id": "Danio rerio#head kidney",
+    "parent": "Danio rerio",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-5530"
+    ]
+  },
+  {
+    "name": "blood cell",
+    "id": "Danio rerio#head kidney#blood cell",
+    "parent": "Danio rerio#head kidney",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-5530"
+    ]
+  },
+  {
+    "name": "Homo sapiens",
+    "id": "Homo sapiens",
+    "parent": "cancer",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-6308",
+      "E-CURD-95",
+      "E-CURD-11",
+      "E-GEOD-139324",
+      "E-GEOD-125970",
+      "E-CURD-97",
+      "E-MTAB-6075",
+      "E-GEOD-75367",
+      "E-MTAB-9435",
+      "E-GEOD-84465",
+      "E-MTAB-10290",
+      "E-MTAB-8559",
+      "E-MTAB-8410",
+      "E-GEOD-135922",
+      "E-GEOD-76312",
+      "E-CURD-6",
+      "E-GEOD-110499",
+      "E-GEOD-99795",
+      "E-MTAB-7249"
+    ]
+  },
+  {
+    "name": "ascending colon",
+    "id": "Homo sapiens#ascending colon",
+    "parent": "Homo sapiens",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "B cell",
+    "id": "Homo sapiens#ascending colon#B cell",
+    "parent": "Homo sapiens#ascending colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "CD4-positive, alpha-beta T cell",
+    "id": "Homo sapiens#ascending colon#CD4-positive, alpha-beta T cell",
+    "parent": "Homo sapiens#ascending colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "CD8-positive, alpha-beta T cell",
+    "id": "Homo sapiens#ascending colon#CD8-positive, alpha-beta T cell",
+    "parent": "Homo sapiens#ascending colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "consensus molecular subtype 1 epithelial cell",
+    "id": "Homo sapiens#ascending colon#consensus molecular subtype 1 epithelial cell",
+    "parent": "Homo sapiens#ascending colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "consensus molecular subtype 2 epithelial cell",
+    "id": "Homo sapiens#ascending colon#consensus molecular subtype 2 epithelial cell",
+    "parent": "Homo sapiens#ascending colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "consensus molecular subtype 3 epithelial cell",
+    "id": "Homo sapiens#ascending colon#consensus molecular subtype 3 epithelial cell",
+    "parent": "Homo sapiens#ascending colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "conventional dendritic cell",
+    "id": "Homo sapiens#ascending colon#conventional dendritic cell",
+    "parent": "Homo sapiens#ascending colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "endothelial cell of lymphatic vessel",
+    "id": "Homo sapiens#ascending colon#endothelial cell of lymphatic vessel",
+    "parent": "Homo sapiens#ascending colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "endothelial stalk cell",
+    "id": "Homo sapiens#ascending colon#endothelial stalk cell",
+    "parent": "Homo sapiens#ascending colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "endothelial tip cell",
+    "id": "Homo sapiens#ascending colon#endothelial tip cell",
+    "parent": "Homo sapiens#ascending colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "enterocyte of epithelium of large intestine",
+    "id": "Homo sapiens#ascending colon#enterocyte of epithelium of large intestine",
+    "parent": "Homo sapiens#ascending colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "epithelial cell of large intestine",
+    "id": "Homo sapiens#ascending colon#epithelial cell of large intestine",
+    "parent": "Homo sapiens#ascending colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "glial cell",
+    "id": "Homo sapiens#ascending colon#glial cell",
+    "parent": "Homo sapiens#ascending colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "goblet cell",
+    "id": "Homo sapiens#ascending colon#goblet cell",
+    "parent": "Homo sapiens#ascending colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "IgA plasma cell",
+    "id": "Homo sapiens#ascending colon#IgA plasma cell",
+    "parent": "Homo sapiens#ascending colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "mast cell",
+    "id": "Homo sapiens#ascending colon#mast cell",
+    "parent": "Homo sapiens#ascending colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "myeloid cell",
+    "id": "Homo sapiens#ascending colon#myeloid cell",
+    "parent": "Homo sapiens#ascending colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "myofibroblast",
+    "id": "Homo sapiens#ascending colon#myofibroblast",
+    "parent": "Homo sapiens#ascending colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "natural killer cell",
+    "id": "Homo sapiens#ascending colon#natural killer cell",
+    "parent": "Homo sapiens#ascending colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "pericyte",
+    "id": "Homo sapiens#ascending colon#pericyte",
+    "parent": "Homo sapiens#ascending colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "plasma cell",
+    "id": "Homo sapiens#ascending colon#plasma cell",
+    "parent": "Homo sapiens#ascending colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "smooth muscle cell of large intestine",
+    "id": "Homo sapiens#ascending colon#smooth muscle cell of large intestine",
+    "parent": "Homo sapiens#ascending colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "stromal cell",
+    "id": "Homo sapiens#ascending colon#stromal cell",
+    "parent": "Homo sapiens#ascending colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "ascitic fluid",
+    "id": "Homo sapiens#ascitic fluid",
+    "parent": "Homo sapiens",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-7249",
+      "E-GEOD-110499"
+    ]
+  },
+  {
+    "name": "neoplastic cell",
+    "id": "Homo sapiens#ascitic fluid#neoplastic cell",
+    "parent": "Homo sapiens#ascitic fluid",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-7249"
+    ]
+  },
+  {
+    "name": "plasma cell",
+    "id": "Homo sapiens#ascitic fluid#plasma cell",
+    "parent": "Homo sapiens#ascitic fluid",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-110499"
+    ]
+  },
+  {
+    "name": "stromal cell",
+    "id": "Homo sapiens#ascitic fluid#stromal cell",
+    "parent": "Homo sapiens#ascitic fluid",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-7249"
+    ]
+  },
+  {
+    "name": "blood",
+    "id": "Homo sapiens#blood",
+    "parent": "Homo sapiens",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-139324",
+      "E-MTAB-6075",
+      "E-GEOD-75367"
+    ]
+  },
+  {
+    "name": "circulating tumor cell",
+    "id": "Homo sapiens#blood#circulating tumor cell",
+    "parent": "Homo sapiens#blood",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-75367"
+    ]
+  },
+  {
+    "name": "leukocyte",
+    "id": "Homo sapiens#blood#leukocyte",
+    "parent": "Homo sapiens#blood",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-139324"
+    ]
+  },
+  {
+    "name": "macrophage",
+    "id": "Homo sapiens#blood#macrophage",
+    "parent": "Homo sapiens#blood",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-6075"
+    ]
+  },
+  {
+    "name": "bone marrow",
+    "id": "Homo sapiens#bone marrow",
+    "parent": "Homo sapiens",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-76312",
+      "E-CURD-6",
+      "E-GEOD-110499"
+    ]
+  },
+  {
+    "name": "bone marrow cell",
+    "id": "Homo sapiens#bone marrow#bone marrow cell",
+    "parent": "Homo sapiens#bone marrow",
+    "value": 1,
+    "experimentAccessions": [
+      "E-CURD-6"
+    ]
+  },
+  {
+    "name": "mononuclear cell of bone marrow",
+    "id": "Homo sapiens#bone marrow#mononuclear cell of bone marrow",
+    "parent": "Homo sapiens#bone marrow",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-76312"
+    ]
+  },
+  {
+    "name": "plasma cell",
+    "id": "Homo sapiens#bone marrow#plasma cell",
+    "parent": "Homo sapiens#bone marrow",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-110499"
+    ]
+  },
+  {
+    "name": "brain",
+    "id": "Homo sapiens#brain",
+    "parent": "Homo sapiens",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-9435",
+      "E-GEOD-84465"
+    ]
+  },
+  {
+    "name": "astrocyte",
+    "id": "Homo sapiens#brain#astrocyte",
+    "parent": "Homo sapiens#brain",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-84465"
+    ]
+  },
+  {
+    "name": "glioblastoma and infiltrating normal cell",
+    "id": "Homo sapiens#brain#glioblastoma and infiltrating normal cell",
+    "parent": "Homo sapiens#brain",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-9435"
+    ]
+  },
+  {
+    "name": "immune cell",
+    "id": "Homo sapiens#brain#immune cell",
+    "parent": "Homo sapiens#brain",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-84465"
+    ]
+  },
+  {
+    "name": "neoplastic cell",
+    "id": "Homo sapiens#brain#neoplastic cell",
+    "parent": "Homo sapiens#brain",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-84465"
+    ]
+  },
+  {
+    "name": "neuron",
+    "id": "Homo sapiens#brain#neuron",
+    "parent": "Homo sapiens#brain",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-84465"
+    ]
+  },
+  {
+    "name": "oligodendrocyte",
+    "id": "Homo sapiens#brain#oligodendrocyte",
+    "parent": "Homo sapiens#brain",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-84465"
+    ]
+  },
+  {
+    "name": "oligodendrocyte precursor cell",
+    "id": "Homo sapiens#brain#oligodendrocyte precursor cell",
+    "parent": "Homo sapiens#brain",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-84465"
+    ]
+  },
+  {
+    "name": "vascular cell",
+    "id": "Homo sapiens#brain#vascular cell",
+    "parent": "Homo sapiens#brain",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-84465"
+    ]
+  },
+  {
+    "name": "bronchiole",
+    "id": "Homo sapiens#bronchiole",
+    "parent": "Homo sapiens",
+    "value": 1,
+    "experimentAccessions": [
+      "E-CURD-11"
+    ]
+  },
+  {
+    "name": "epithelial cell",
+    "id": "Homo sapiens#bronchiole#epithelial cell",
+    "parent": "Homo sapiens#bronchiole",
+    "value": 1,
+    "experimentAccessions": [
+      "E-CURD-11"
+    ]
+  },
+  {
+    "name": "caecum",
+    "id": "Homo sapiens#caecum",
+    "parent": "Homo sapiens",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "B cell",
+    "id": "Homo sapiens#caecum#B cell",
+    "parent": "Homo sapiens#caecum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "brush cell of epithelium proper of large intestine",
+    "id": "Homo sapiens#caecum#brush cell of epithelium proper of large intestine",
+    "parent": "Homo sapiens#caecum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "CD4-positive, alpha-beta T cell",
+    "id": "Homo sapiens#caecum#CD4-positive, alpha-beta T cell",
+    "parent": "Homo sapiens#caecum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "CD8-positive, alpha-beta T cell",
+    "id": "Homo sapiens#caecum#CD8-positive, alpha-beta T cell",
+    "parent": "Homo sapiens#caecum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "consensus molecular subtype 1 epithelial cell",
+    "id": "Homo sapiens#caecum#consensus molecular subtype 1 epithelial cell",
+    "parent": "Homo sapiens#caecum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "consensus molecular subtype 2 epithelial cell",
+    "id": "Homo sapiens#caecum#consensus molecular subtype 2 epithelial cell",
+    "parent": "Homo sapiens#caecum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "consensus molecular subtype 3 epithelial cell",
+    "id": "Homo sapiens#caecum#consensus molecular subtype 3 epithelial cell",
+    "parent": "Homo sapiens#caecum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "conventional dendritic cell",
+    "id": "Homo sapiens#caecum#conventional dendritic cell",
+    "parent": "Homo sapiens#caecum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "endothelial cell of lymphatic vessel",
+    "id": "Homo sapiens#caecum#endothelial cell of lymphatic vessel",
+    "parent": "Homo sapiens#caecum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "endothelial stalk cell",
+    "id": "Homo sapiens#caecum#endothelial stalk cell",
+    "parent": "Homo sapiens#caecum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "endothelial tip cell",
+    "id": "Homo sapiens#caecum#endothelial tip cell",
+    "parent": "Homo sapiens#caecum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "enterocyte of epithelium of large intestine",
+    "id": "Homo sapiens#caecum#enterocyte of epithelium of large intestine",
+    "parent": "Homo sapiens#caecum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "epithelial cell of large intestine",
+    "id": "Homo sapiens#caecum#epithelial cell of large intestine",
+    "parent": "Homo sapiens#caecum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "gamma-delta T cell",
+    "id": "Homo sapiens#caecum#gamma-delta T cell",
+    "parent": "Homo sapiens#caecum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "glial cell",
+    "id": "Homo sapiens#caecum#glial cell",
+    "parent": "Homo sapiens#caecum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "goblet cell",
+    "id": "Homo sapiens#caecum#goblet cell",
+    "parent": "Homo sapiens#caecum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "IgA plasma cell",
+    "id": "Homo sapiens#caecum#IgA plasma cell",
+    "parent": "Homo sapiens#caecum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "mast cell",
+    "id": "Homo sapiens#caecum#mast cell",
+    "parent": "Homo sapiens#caecum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "myeloid cell",
+    "id": "Homo sapiens#caecum#myeloid cell",
+    "parent": "Homo sapiens#caecum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "myofibroblast",
+    "id": "Homo sapiens#caecum#myofibroblast",
+    "parent": "Homo sapiens#caecum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "natural killer cell",
+    "id": "Homo sapiens#caecum#natural killer cell",
+    "parent": "Homo sapiens#caecum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "pericyte",
+    "id": "Homo sapiens#caecum#pericyte",
+    "parent": "Homo sapiens#caecum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "plasma cell",
+    "id": "Homo sapiens#caecum#plasma cell",
+    "parent": "Homo sapiens#caecum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "regulatory T cell",
+    "id": "Homo sapiens#caecum#regulatory T cell",
+    "parent": "Homo sapiens#caecum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "smooth muscle cell of large intestine",
+    "id": "Homo sapiens#caecum#smooth muscle cell of large intestine",
+    "parent": "Homo sapiens#caecum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "stromal cell",
+    "id": "Homo sapiens#caecum#stromal cell",
+    "parent": "Homo sapiens#caecum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "T cell",
+    "id": "Homo sapiens#caecum#T cell",
+    "parent": "Homo sapiens#caecum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "T follicular helper cell",
+    "id": "Homo sapiens#caecum#T follicular helper cell",
+    "parent": "Homo sapiens#caecum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "T-helper 17 cell",
+    "id": "Homo sapiens#caecum#T-helper 17 cell",
+    "parent": "Homo sapiens#caecum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "colon",
+    "id": "Homo sapiens#colon",
+    "parent": "Homo sapiens",
+    "value": 1,
+    "experimentAccessions": [
+      "E-CURD-95",
+      "E-GEOD-125970",
+      "E-CURD-97"
+    ]
+  },
+  {
+    "name": "CD4-positive, CD25-positive, alpha-beta regulatory T cell",
+    "id": "Homo sapiens#colon#CD4-positive, CD25-positive, alpha-beta regulatory T cell",
+    "parent": "Homo sapiens#colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-CURD-97"
+    ]
+  },
+  {
+    "name": "central memory CD4-positive, alpha-beta T cell",
+    "id": "Homo sapiens#colon#central memory CD4-positive, alpha-beta T cell",
+    "parent": "Homo sapiens#colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-CURD-97"
+    ]
+  },
+  {
+    "name": "effector memory CD4-positive, alpha-beta T cell",
+    "id": "Homo sapiens#colon#effector memory CD4-positive, alpha-beta T cell",
+    "parent": "Homo sapiens#colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-CURD-97"
+    ]
+  },
+  {
+    "name": "enterocyte of epithelium of large intestine",
+    "id": "Homo sapiens#colon#enterocyte of epithelium of large intestine",
+    "parent": "Homo sapiens#colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-125970"
+    ]
+  },
+  {
+    "name": "epithelial progenitor cell of large intestine",
+    "id": "Homo sapiens#colon#epithelial progenitor cell of large intestine",
+    "parent": "Homo sapiens#colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-125970"
+    ]
+  },
+  {
+    "name": "intestinal crypt stem cell",
+    "id": "Homo sapiens#colon#intestinal crypt stem cell",
+    "parent": "Homo sapiens#colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-125970"
+    ]
+  },
+  {
+    "name": "intestinal crypt transit amplifying cell",
+    "id": "Homo sapiens#colon#intestinal crypt transit amplifying cell",
+    "parent": "Homo sapiens#colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-125970"
+    ]
+  },
+  {
+    "name": "intestinal enteroendocrine cell",
+    "id": "Homo sapiens#colon#intestinal enteroendocrine cell",
+    "parent": "Homo sapiens#colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-125970"
+    ]
+  },
+  {
+    "name": "intestinal epithelial cell",
+    "id": "Homo sapiens#colon#intestinal epithelial cell",
+    "parent": "Homo sapiens#colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-125970"
+    ]
+  },
+  {
+    "name": "large intestine goblet cell",
+    "id": "Homo sapiens#colon#large intestine goblet cell",
+    "parent": "Homo sapiens#colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-125970"
+    ]
+  },
+  {
+    "name": "paneth-like cell",
+    "id": "Homo sapiens#colon#paneth-like cell",
+    "parent": "Homo sapiens#colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-125970"
+    ]
+  },
+  {
+    "name": "T cell",
+    "id": "Homo sapiens#colon#T cell",
+    "parent": "Homo sapiens#colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-CURD-95"
+    ]
+  },
+  {
+    "name": "ileum",
+    "id": "Homo sapiens#ileum",
+    "parent": "Homo sapiens",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-125970"
+    ]
+  },
+  {
+    "name": "enterocyte of epithelium of small intestine",
+    "id": "Homo sapiens#ileum#enterocyte of epithelium of small intestine",
+    "parent": "Homo sapiens#ileum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-125970"
+    ]
+  },
+  {
+    "name": "epithelial progenitor cell of small intestine",
+    "id": "Homo sapiens#ileum#epithelial progenitor cell of small intestine",
+    "parent": "Homo sapiens#ileum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-125970"
+    ]
+  },
+  {
+    "name": "intestinal crypt stem cell",
+    "id": "Homo sapiens#ileum#intestinal crypt stem cell",
+    "parent": "Homo sapiens#ileum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-125970"
+    ]
+  },
+  {
+    "name": "intestinal crypt transit amplifying cell",
+    "id": "Homo sapiens#ileum#intestinal crypt transit amplifying cell",
+    "parent": "Homo sapiens#ileum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-125970"
+    ]
+  },
+  {
+    "name": "intestinal enteroendocrine cell",
+    "id": "Homo sapiens#ileum#intestinal enteroendocrine cell",
+    "parent": "Homo sapiens#ileum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-125970"
+    ]
+  },
+  {
+    "name": "intestinal epithelial cell",
+    "id": "Homo sapiens#ileum#intestinal epithelial cell",
+    "parent": "Homo sapiens#ileum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-125970"
+    ]
+  },
+  {
+    "name": "paneth cell of epithelium of small intestine",
+    "id": "Homo sapiens#ileum#paneth cell of epithelium of small intestine",
+    "parent": "Homo sapiens#ileum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-125970"
+    ]
+  },
+  {
+    "name": "small intestine goblet cell",
+    "id": "Homo sapiens#ileum#small intestine goblet cell",
+    "parent": "Homo sapiens#ileum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-125970"
+    ]
+  },
+  {
+    "name": "liver",
+    "id": "Homo sapiens#liver",
+    "parent": "Homo sapiens",
+    "value": 1,
+    "experimentAccessions": [
+      "E-CURD-95"
+    ]
+  },
+  {
+    "name": "T cell",
+    "id": "Homo sapiens#liver#T cell",
+    "parent": "Homo sapiens#liver",
+    "value": 1,
+    "experimentAccessions": [
+      "E-CURD-95"
+    ]
+  },
+  {
+    "name": "lung",
+    "id": "Homo sapiens#lung",
+    "parent": "Homo sapiens",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-6308",
+      "E-CURD-95",
+      "E-CURD-11"
+    ]
+  },
+  {
+    "name": "endothelial cell",
+    "id": "Homo sapiens#lung#endothelial cell",
+    "parent": "Homo sapiens#lung",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-6308"
+    ]
+  },
+  {
+    "name": "not applicable",
+    "id": "Homo sapiens#lung#not applicable",
+    "parent": "Homo sapiens#lung",
+    "value": 1,
+    "experimentAccessions": [
+      "E-CURD-11"
+    ]
+  },
+  {
+    "name": "T cell",
+    "id": "Homo sapiens#lung#T cell",
+    "parent": "Homo sapiens#lung",
+    "value": 1,
+    "experimentAccessions": [
+      "E-CURD-95"
+    ]
+  },
+  {
+    "name": "middle lobe of right lung",
+    "id": "Homo sapiens#middle lobe of right lung",
+    "parent": "Homo sapiens",
+    "value": 1,
+    "experimentAccessions": [
+      "E-CURD-11"
+    ]
+  },
+  {
+    "name": "not applicable",
+    "id": "Homo sapiens#middle lobe of right lung#not applicable",
+    "parent": "Homo sapiens#middle lobe of right lung",
+    "value": 1,
+    "experimentAccessions": [
+      "E-CURD-11"
+    ]
+  },
+  {
+    "name": "neoplasm",
+    "id": "Homo sapiens#neoplasm",
+    "parent": "Homo sapiens",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-139324"
+    ]
+  },
+  {
+    "name": "leukocyte",
+    "id": "Homo sapiens#neoplasm#leukocyte",
+    "parent": "Homo sapiens#neoplasm",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-139324"
+    ]
+  },
+  {
+    "name": "peritoneal fluid",
+    "id": "Homo sapiens#peritoneal fluid",
+    "parent": "Homo sapiens",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8559"
+    ]
+  },
+  {
+    "name": "mix of stromal fibroblasts and epithelial tumour cells",
+    "id": "Homo sapiens#peritoneal fluid#mix of stromal fibroblasts and epithelial tumour cells",
+    "parent": "Homo sapiens#peritoneal fluid",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8559"
+    ]
+  },
+  {
+    "name": "pigmented layer of retina and optic choroid",
+    "id": "Homo sapiens#pigmented layer of retina and optic choroid",
+    "parent": "Homo sapiens",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-135922"
+    ]
+  },
+  {
+    "name": "capillary endothelial cell",
+    "id": "Homo sapiens#pigmented layer of retina and optic choroid#capillary endothelial cell",
+    "parent": "Homo sapiens#pigmented layer of retina and optic choroid",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-135922"
+    ]
+  },
+  {
+    "name": "endothelial cell of artery",
+    "id": "Homo sapiens#pigmented layer of retina and optic choroid#endothelial cell of artery",
+    "parent": "Homo sapiens#pigmented layer of retina and optic choroid",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-135922"
+    ]
+  },
+  {
+    "name": "fibroblast",
+    "id": "Homo sapiens#pigmented layer of retina and optic choroid#fibroblast",
+    "parent": "Homo sapiens#pigmented layer of retina and optic choroid",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-135922"
+    ]
+  },
+  {
+    "name": "leukocyte/other",
+    "id": "Homo sapiens#pigmented layer of retina and optic choroid#leukocyte/other",
+    "parent": "Homo sapiens#pigmented layer of retina and optic choroid",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-135922"
+    ]
+  },
+  {
+    "name": "macrophage",
+    "id": "Homo sapiens#pigmented layer of retina and optic choroid#macrophage",
+    "parent": "Homo sapiens#pigmented layer of retina and optic choroid",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-135922"
+    ]
+  },
+  {
+    "name": "pericyte",
+    "id": "Homo sapiens#pigmented layer of retina and optic choroid#pericyte",
+    "parent": "Homo sapiens#pigmented layer of retina and optic choroid",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-135922"
+    ]
+  },
+  {
+    "name": "retinal pigment epithelial cell/retinal rod cell/melanocyte",
+    "id": "Homo sapiens#pigmented layer of retina and optic choroid#retinal pigment epithelial cell/retinal rod cell/melanocyte",
+    "parent": "Homo sapiens#pigmented layer of retina and optic choroid",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-135922"
+    ]
+  },
+  {
+    "name": "Schwann cell",
+    "id": "Homo sapiens#pigmented layer of retina and optic choroid#Schwann cell",
+    "parent": "Homo sapiens#pigmented layer of retina and optic choroid",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-135922"
+    ]
+  },
+  {
+    "name": "vein endothelial cell",
+    "id": "Homo sapiens#pigmented layer of retina and optic choroid#vein endothelial cell",
+    "parent": "Homo sapiens#pigmented layer of retina and optic choroid",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-135922"
+    ]
+  },
+  {
+    "name": "prostate gland",
+    "id": "Homo sapiens#prostate gland",
+    "parent": "Homo sapiens",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-99795"
+    ]
+  },
+  {
+    "name": "epithelial cell",
+    "id": "Homo sapiens#prostate gland#epithelial cell",
+    "parent": "Homo sapiens#prostate gland",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-99795"
+    ]
+  },
+  {
+    "name": "rectosigmoid junction",
+    "id": "Homo sapiens#rectosigmoid junction",
+    "parent": "Homo sapiens",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "B cell",
+    "id": "Homo sapiens#rectosigmoid junction#B cell",
+    "parent": "Homo sapiens#rectosigmoid junction",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "brush cell of epithelium proper of large intestine",
+    "id": "Homo sapiens#rectosigmoid junction#brush cell of epithelium proper of large intestine",
+    "parent": "Homo sapiens#rectosigmoid junction",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "CD4-positive, alpha-beta T cell",
+    "id": "Homo sapiens#rectosigmoid junction#CD4-positive, alpha-beta T cell",
+    "parent": "Homo sapiens#rectosigmoid junction",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "CD8-positive, alpha-beta T cell",
+    "id": "Homo sapiens#rectosigmoid junction#CD8-positive, alpha-beta T cell",
+    "parent": "Homo sapiens#rectosigmoid junction",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "consensus molecular subtype 1 epithelial cell",
+    "id": "Homo sapiens#rectosigmoid junction#consensus molecular subtype 1 epithelial cell",
+    "parent": "Homo sapiens#rectosigmoid junction",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "consensus molecular subtype 2 epithelial cell",
+    "id": "Homo sapiens#rectosigmoid junction#consensus molecular subtype 2 epithelial cell",
+    "parent": "Homo sapiens#rectosigmoid junction",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "consensus molecular subtype 3 epithelial cell",
+    "id": "Homo sapiens#rectosigmoid junction#consensus molecular subtype 3 epithelial cell",
+    "parent": "Homo sapiens#rectosigmoid junction",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "conventional dendritic cell",
+    "id": "Homo sapiens#rectosigmoid junction#conventional dendritic cell",
+    "parent": "Homo sapiens#rectosigmoid junction",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "endothelial cell of lymphatic vessel",
+    "id": "Homo sapiens#rectosigmoid junction#endothelial cell of lymphatic vessel",
+    "parent": "Homo sapiens#rectosigmoid junction",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "endothelial stalk cell",
+    "id": "Homo sapiens#rectosigmoid junction#endothelial stalk cell",
+    "parent": "Homo sapiens#rectosigmoid junction",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "endothelial tip cell",
+    "id": "Homo sapiens#rectosigmoid junction#endothelial tip cell",
+    "parent": "Homo sapiens#rectosigmoid junction",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "enterocyte of epithelium of large intestine",
+    "id": "Homo sapiens#rectosigmoid junction#enterocyte of epithelium of large intestine",
+    "parent": "Homo sapiens#rectosigmoid junction",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "epithelial cell of large intestine",
+    "id": "Homo sapiens#rectosigmoid junction#epithelial cell of large intestine",
+    "parent": "Homo sapiens#rectosigmoid junction",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "gamma-delta T cell",
+    "id": "Homo sapiens#rectosigmoid junction#gamma-delta T cell",
+    "parent": "Homo sapiens#rectosigmoid junction",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "glial cell",
+    "id": "Homo sapiens#rectosigmoid junction#glial cell",
+    "parent": "Homo sapiens#rectosigmoid junction",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "goblet cell",
+    "id": "Homo sapiens#rectosigmoid junction#goblet cell",
+    "parent": "Homo sapiens#rectosigmoid junction",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "IgA plasma cell",
+    "id": "Homo sapiens#rectosigmoid junction#IgA plasma cell",
+    "parent": "Homo sapiens#rectosigmoid junction",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "mast cell",
+    "id": "Homo sapiens#rectosigmoid junction#mast cell",
+    "parent": "Homo sapiens#rectosigmoid junction",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "myeloid cell",
+    "id": "Homo sapiens#rectosigmoid junction#myeloid cell",
+    "parent": "Homo sapiens#rectosigmoid junction",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "myofibroblast",
+    "id": "Homo sapiens#rectosigmoid junction#myofibroblast",
+    "parent": "Homo sapiens#rectosigmoid junction",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "natural killer cell",
+    "id": "Homo sapiens#rectosigmoid junction#natural killer cell",
+    "parent": "Homo sapiens#rectosigmoid junction",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "pericyte",
+    "id": "Homo sapiens#rectosigmoid junction#pericyte",
+    "parent": "Homo sapiens#rectosigmoid junction",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "plasma cell",
+    "id": "Homo sapiens#rectosigmoid junction#plasma cell",
+    "parent": "Homo sapiens#rectosigmoid junction",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "regulatory T cell",
+    "id": "Homo sapiens#rectosigmoid junction#regulatory T cell",
+    "parent": "Homo sapiens#rectosigmoid junction",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "smooth muscle cell of large intestine",
+    "id": "Homo sapiens#rectosigmoid junction#smooth muscle cell of large intestine",
+    "parent": "Homo sapiens#rectosigmoid junction",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "stromal cell",
+    "id": "Homo sapiens#rectosigmoid junction#stromal cell",
+    "parent": "Homo sapiens#rectosigmoid junction",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "T cell",
+    "id": "Homo sapiens#rectosigmoid junction#T cell",
+    "parent": "Homo sapiens#rectosigmoid junction",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "T follicular helper cell",
+    "id": "Homo sapiens#rectosigmoid junction#T follicular helper cell",
+    "parent": "Homo sapiens#rectosigmoid junction",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "T-helper 17 cell",
+    "id": "Homo sapiens#rectosigmoid junction#T-helper 17 cell",
+    "parent": "Homo sapiens#rectosigmoid junction",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "rectum",
+    "id": "Homo sapiens#rectum",
+    "parent": "Homo sapiens",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-125970"
+    ]
+  },
+  {
+    "name": "enterocyte of epithelium of large intestine",
+    "id": "Homo sapiens#rectum#enterocyte of epithelium of large intestine",
+    "parent": "Homo sapiens#rectum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-125970"
+    ]
+  },
+  {
+    "name": "epithelial progenitor cell of large intestine",
+    "id": "Homo sapiens#rectum#epithelial progenitor cell of large intestine",
+    "parent": "Homo sapiens#rectum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-125970"
+    ]
+  },
+  {
+    "name": "intestinal crypt stem cell",
+    "id": "Homo sapiens#rectum#intestinal crypt stem cell",
+    "parent": "Homo sapiens#rectum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-125970"
+    ]
+  },
+  {
+    "name": "intestinal crypt transit amplifying cell",
+    "id": "Homo sapiens#rectum#intestinal crypt transit amplifying cell",
+    "parent": "Homo sapiens#rectum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-125970"
+    ]
+  },
+  {
+    "name": "intestinal enteroendocrine cell",
+    "id": "Homo sapiens#rectum#intestinal enteroendocrine cell",
+    "parent": "Homo sapiens#rectum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-125970"
+    ]
+  },
+  {
+    "name": "intestinal epithelial cell",
+    "id": "Homo sapiens#rectum#intestinal epithelial cell",
+    "parent": "Homo sapiens#rectum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-125970"
+    ]
+  },
+  {
+    "name": "large intestine goblet cell",
+    "id": "Homo sapiens#rectum#large intestine goblet cell",
+    "parent": "Homo sapiens#rectum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-125970"
+    ]
+  },
+  {
+    "name": "paneth-like cell",
+    "id": "Homo sapiens#rectum#paneth-like cell",
+    "parent": "Homo sapiens#rectum",
+    "value": 1,
+    "experimentAccessions": [
+      "E-GEOD-125970"
+    ]
+  },
+  {
+    "name": "sigmoid colon",
+    "id": "Homo sapiens#sigmoid colon",
+    "parent": "Homo sapiens",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "B cell",
+    "id": "Homo sapiens#sigmoid colon#B cell",
+    "parent": "Homo sapiens#sigmoid colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "brush cell of epithelium proper of large intestine",
+    "id": "Homo sapiens#sigmoid colon#brush cell of epithelium proper of large intestine",
+    "parent": "Homo sapiens#sigmoid colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "CD4-positive, alpha-beta T cell",
+    "id": "Homo sapiens#sigmoid colon#CD4-positive, alpha-beta T cell",
+    "parent": "Homo sapiens#sigmoid colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "CD8-positive, alpha-beta T cell",
+    "id": "Homo sapiens#sigmoid colon#CD8-positive, alpha-beta T cell",
+    "parent": "Homo sapiens#sigmoid colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "consensus molecular subtype 1 epithelial cell",
+    "id": "Homo sapiens#sigmoid colon#consensus molecular subtype 1 epithelial cell",
+    "parent": "Homo sapiens#sigmoid colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "consensus molecular subtype 2 epithelial cell",
+    "id": "Homo sapiens#sigmoid colon#consensus molecular subtype 2 epithelial cell",
+    "parent": "Homo sapiens#sigmoid colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "consensus molecular subtype 3 epithelial cell",
+    "id": "Homo sapiens#sigmoid colon#consensus molecular subtype 3 epithelial cell",
+    "parent": "Homo sapiens#sigmoid colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "conventional dendritic cell",
+    "id": "Homo sapiens#sigmoid colon#conventional dendritic cell",
+    "parent": "Homo sapiens#sigmoid colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "endothelial cell of lymphatic vessel",
+    "id": "Homo sapiens#sigmoid colon#endothelial cell of lymphatic vessel",
+    "parent": "Homo sapiens#sigmoid colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "endothelial stalk cell",
+    "id": "Homo sapiens#sigmoid colon#endothelial stalk cell",
+    "parent": "Homo sapiens#sigmoid colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "endothelial tip cell",
+    "id": "Homo sapiens#sigmoid colon#endothelial tip cell",
+    "parent": "Homo sapiens#sigmoid colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "enterocyte of epithelium of large intestine",
+    "id": "Homo sapiens#sigmoid colon#enterocyte of epithelium of large intestine",
+    "parent": "Homo sapiens#sigmoid colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "epithelial cell of large intestine",
+    "id": "Homo sapiens#sigmoid colon#epithelial cell of large intestine",
+    "parent": "Homo sapiens#sigmoid colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "gamma-delta T cell",
+    "id": "Homo sapiens#sigmoid colon#gamma-delta T cell",
+    "parent": "Homo sapiens#sigmoid colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "glial cell",
+    "id": "Homo sapiens#sigmoid colon#glial cell",
+    "parent": "Homo sapiens#sigmoid colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "goblet cell",
+    "id": "Homo sapiens#sigmoid colon#goblet cell",
+    "parent": "Homo sapiens#sigmoid colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "IgA plasma cell",
+    "id": "Homo sapiens#sigmoid colon#IgA plasma cell",
+    "parent": "Homo sapiens#sigmoid colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "mast cell",
+    "id": "Homo sapiens#sigmoid colon#mast cell",
+    "parent": "Homo sapiens#sigmoid colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "myeloid cell",
+    "id": "Homo sapiens#sigmoid colon#myeloid cell",
+    "parent": "Homo sapiens#sigmoid colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "myofibroblast",
+    "id": "Homo sapiens#sigmoid colon#myofibroblast",
+    "parent": "Homo sapiens#sigmoid colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "natural killer cell",
+    "id": "Homo sapiens#sigmoid colon#natural killer cell",
+    "parent": "Homo sapiens#sigmoid colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "pericyte",
+    "id": "Homo sapiens#sigmoid colon#pericyte",
+    "parent": "Homo sapiens#sigmoid colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "plasma cell",
+    "id": "Homo sapiens#sigmoid colon#plasma cell",
+    "parent": "Homo sapiens#sigmoid colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "regulatory T cell",
+    "id": "Homo sapiens#sigmoid colon#regulatory T cell",
+    "parent": "Homo sapiens#sigmoid colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "smooth muscle cell of large intestine",
+    "id": "Homo sapiens#sigmoid colon#smooth muscle cell of large intestine",
+    "parent": "Homo sapiens#sigmoid colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "stromal cell",
+    "id": "Homo sapiens#sigmoid colon#stromal cell",
+    "parent": "Homo sapiens#sigmoid colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "T cell",
+    "id": "Homo sapiens#sigmoid colon#T cell",
+    "parent": "Homo sapiens#sigmoid colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "T follicular helper cell",
+    "id": "Homo sapiens#sigmoid colon#T follicular helper cell",
+    "parent": "Homo sapiens#sigmoid colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "T-helper 17 cell",
+    "id": "Homo sapiens#sigmoid colon#T-helper 17 cell",
+    "parent": "Homo sapiens#sigmoid colon",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-8410"
+    ]
+  },
+  {
+    "name": "skin of trunk",
+    "id": "Homo sapiens#skin of trunk",
+    "parent": "Homo sapiens",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-10290"
+    ]
+  },
+  {
+    "name": "fibroblast",
+    "id": "Homo sapiens#skin of trunk#fibroblast",
+    "parent": "Homo sapiens#skin of trunk",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-10290"
+    ]
+  },
+  {
+    "name": "Mus musculus",
+    "id": "Mus musculus",
+    "parent": "cancer",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-6487",
+      "E-CURD-96",
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "brachial lymph node",
+    "id": "Mus musculus#brachial lymph node",
+    "parent": "Mus musculus",
+    "value": 1,
+    "experimentAccessions": [
+      "E-CURD-96"
+    ]
+  },
+  {
+    "name": "CD4-positive, alpha-beta memory T cell",
+    "id": "Mus musculus#brachial lymph node#CD4-positive, alpha-beta memory T cell",
+    "parent": "Mus musculus#brachial lymph node",
+    "value": 1,
+    "experimentAccessions": [
+      "E-CURD-96"
+    ]
+  },
+  {
+    "name": "CD4-positive, CD25-positive, alpha-beta regulatory T cell",
+    "id": "Mus musculus#brachial lymph node#CD4-positive, CD25-positive, alpha-beta regulatory T cell",
+    "parent": "Mus musculus#brachial lymph node",
+    "value": 1,
+    "experimentAccessions": [
+      "E-CURD-96"
+    ]
+  },
+  {
+    "name": "lymph node",
+    "id": "Mus musculus#lymph node",
+    "parent": "Mus musculus",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "B cell",
+    "id": "Mus musculus#lymph node#B cell",
+    "parent": "Mus musculus#lymph node",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "cancer associated fibroblast 1",
+    "id": "Mus musculus#lymph node#cancer associated fibroblast 1",
+    "parent": "Mus musculus#lymph node",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "cancer associated fibroblast 2",
+    "id": "Mus musculus#lymph node#cancer associated fibroblast 2",
+    "parent": "Mus musculus#lymph node",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "cancer associated fibroblast 3",
+    "id": "Mus musculus#lymph node#cancer associated fibroblast 3",
+    "parent": "Mus musculus#lymph node",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "conventional dendritic cell 1",
+    "id": "Mus musculus#lymph node#conventional dendritic cell 1",
+    "parent": "Mus musculus#lymph node",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "conventional dendritic cell 2",
+    "id": "Mus musculus#lymph node#conventional dendritic cell 2",
+    "parent": "Mus musculus#lymph node",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "gamma-delta T cell/mucosal invariant T cell",
+    "id": "Mus musculus#lymph node#gamma-delta T cell/mucosal invariant T cell",
+    "parent": "Mus musculus#lymph node",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "lymph node endothelial cell",
+    "id": "Mus musculus#lymph node#lymph node endothelial cell",
+    "parent": "Mus musculus#lymph node",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "lymph node fibroblast",
+    "id": "Mus musculus#lymph node#lymph node fibroblast",
+    "parent": "Mus musculus#lymph node",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "lymph node T cell",
+    "id": "Mus musculus#lymph node#lymph node T cell",
+    "parent": "Mus musculus#lymph node",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "lymphatic endothelial cell",
+    "id": "Mus musculus#lymph node#lymphatic endothelial cell",
+    "parent": "Mus musculus#lymph node",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "macrophage/monocyte",
+    "id": "Mus musculus#lymph node#macrophage/monocyte",
+    "parent": "Mus musculus#lymph node",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "migratory dendritic cell",
+    "id": "Mus musculus#lymph node#migratory dendritic cell",
+    "parent": "Mus musculus#lymph node",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "natural killer cell",
+    "id": "Mus musculus#lymph node#natural killer cell",
+    "parent": "Mus musculus#lymph node",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "not available",
+    "id": "Mus musculus#lymph node#not available",
+    "parent": "Mus musculus#lymph node",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "plasmacytoid dendritic cell",
+    "id": "Mus musculus#lymph node#plasmacytoid dendritic cell",
+    "parent": "Mus musculus#lymph node",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "tumor T cell",
+    "id": "Mus musculus#lymph node#tumor T cell",
+    "parent": "Mus musculus#lymph node",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "tumour endothelial cell",
+    "id": "Mus musculus#lymph node#tumour endothelial cell",
+    "parent": "Mus musculus#lymph node",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "skin",
+    "id": "Mus musculus#skin",
+    "parent": "Mus musculus",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2",
+      "E-CURD-96"
+    ]
+  },
+  {
+    "name": "B cell",
+    "id": "Mus musculus#skin#B cell",
+    "parent": "Mus musculus#skin",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "cancer associated fibroblast 1",
+    "id": "Mus musculus#skin#cancer associated fibroblast 1",
+    "parent": "Mus musculus#skin",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "cancer associated fibroblast 2",
+    "id": "Mus musculus#skin#cancer associated fibroblast 2",
+    "parent": "Mus musculus#skin",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "cancer associated fibroblast 3",
+    "id": "Mus musculus#skin#cancer associated fibroblast 3",
+    "parent": "Mus musculus#skin",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "CD4-positive, alpha-beta memory T cell",
+    "id": "Mus musculus#skin#CD4-positive, alpha-beta memory T cell",
+    "parent": "Mus musculus#skin",
+    "value": 1,
+    "experimentAccessions": [
+      "E-CURD-96"
+    ]
+  },
+  {
+    "name": "CD4-positive, CD25-positive, alpha-beta regulatory T cell",
+    "id": "Mus musculus#skin#CD4-positive, CD25-positive, alpha-beta regulatory T cell",
+    "parent": "Mus musculus#skin",
+    "value": 1,
+    "experimentAccessions": [
+      "E-CURD-96"
+    ]
+  },
+  {
+    "name": "conventional dendritic cell 1",
+    "id": "Mus musculus#skin#conventional dendritic cell 1",
+    "parent": "Mus musculus#skin",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "conventional dendritic cell 2",
+    "id": "Mus musculus#skin#conventional dendritic cell 2",
+    "parent": "Mus musculus#skin",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "gamma-delta T cell/mucosal invariant T cell",
+    "id": "Mus musculus#skin#gamma-delta T cell/mucosal invariant T cell",
+    "parent": "Mus musculus#skin",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "lymph node endothelial cell",
+    "id": "Mus musculus#skin#lymph node endothelial cell",
+    "parent": "Mus musculus#skin",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "lymph node fibroblast",
+    "id": "Mus musculus#skin#lymph node fibroblast",
+    "parent": "Mus musculus#skin",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "lymph node T cell",
+    "id": "Mus musculus#skin#lymph node T cell",
+    "parent": "Mus musculus#skin",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "lymphatic endothelial cell",
+    "id": "Mus musculus#skin#lymphatic endothelial cell",
+    "parent": "Mus musculus#skin",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "macrophage/monocyte",
+    "id": "Mus musculus#skin#macrophage/monocyte",
+    "parent": "Mus musculus#skin",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "migratory dendritic cell",
+    "id": "Mus musculus#skin#migratory dendritic cell",
+    "parent": "Mus musculus#skin",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "natural killer cell",
+    "id": "Mus musculus#skin#natural killer cell",
+    "parent": "Mus musculus#skin",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "not available",
+    "id": "Mus musculus#skin#not available",
+    "parent": "Mus musculus#skin",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "plasmacytoid dendritic cell",
+    "id": "Mus musculus#skin#plasmacytoid dendritic cell",
+    "parent": "Mus musculus#skin",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "tumor T cell",
+    "id": "Mus musculus#skin#tumor T cell",
+    "parent": "Mus musculus#skin",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "tumour endothelial cell",
+    "id": "Mus musculus#skin#tumour endothelial cell",
+    "parent": "Mus musculus#skin",
+    "value": 1,
+    "experimentAccessions": [
+      "E-EHCA-2"
+    ]
+  },
+  {
+    "name": "spleen",
+    "id": "Mus musculus#spleen",
+    "parent": "Mus musculus",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-6487",
+      "E-CURD-96"
+    ]
+  },
+  {
+    "name": "CD4-positive, alpha-beta memory T cell",
+    "id": "Mus musculus#spleen#CD4-positive, alpha-beta memory T cell",
+    "parent": "Mus musculus#spleen",
+    "value": 1,
+    "experimentAccessions": [
+      "E-CURD-96"
+    ]
+  },
+  {
+    "name": "CD4-positive, CD25-positive, alpha-beta regulatory T cell",
+    "id": "Mus musculus#spleen#CD4-positive, CD25-positive, alpha-beta regulatory T cell",
+    "parent": "Mus musculus#spleen",
+    "value": 1,
+    "experimentAccessions": [
+      "E-CURD-96"
+    ]
+  },
+  {
+    "name": "leukocyte",
+    "id": "Mus musculus#spleen#leukocyte",
+    "parent": "Mus musculus#spleen",
+    "value": 1,
+    "experimentAccessions": [
+      "E-MTAB-6487"
+    ]
+  }
+]

--- a/packages/scxa-cell-type-wheel/src/CellTypeWheel.js
+++ b/packages/scxa-cell-type-wheel/src/CellTypeWheel.js
@@ -68,8 +68,7 @@ class CellTypeWheel extends React.Component {
             }
           },
           dataLabels: {
-            format: `{point.name}`,
-            rotationMode: `circular`
+            format: `{point.name}`
           },
           levels: [{
             level: 2,


### PR DESCRIPTION
Cell type data labels are hidden while in a small window for example Homo Sapiens > brain. I fixed it by disabling the `rotationMode` and add a cypress test for it.