### PR TITLE
 📦 scxa-tsne-plot 💬 feature: Use default plot method and parameterisation from backend props

### DIFF
--- a/packages/scxa-tsne-plot/html/Demo.js
+++ b/packages/scxa-tsne-plot/html/Demo.js
@@ -91,7 +91,7 @@ const experiment6 = {
       label: `inferred cell type - ontology labels`
     }
   ],
-  defaultPlotTypeAndParameterisation: {"t-SNE": {"perplexity": 50}, "UMAP": {"n_neighbors": 100}},
+  defaultPlotTypeAndParameterisation: {"tsne": {"perplexity": 50}, "umap": {"n_neighbors": 100}},
   plotTypesAndOptions: {
     "tsne": [{ "perplexity": 40 }, { "perplexity": 25 }, { "perplexity": 45 },{ "perplexity": 1 },{ "perplexity": 30 },
     {"perplexity": 10 },{ "perplexity": 15 },{ "perplexity": 50 },{ "perplexity": 35 },{ "perplexity": 20 },{ "perplexity": 5 }],
@@ -128,7 +128,7 @@ const plotTypeDropdown =  [
     plotOptions: plotTypesAndOptions.umap
   },
   {
-    plotType: `t-SNE`,
+    plotType: `tSNE`,
     plotOptions: plotTypesAndOptions.tsne
   }
 ]
@@ -205,10 +205,10 @@ class Demo extends React.Component {
           onChangePlotTypes={
               (plotOption) => {
                 this.setState({
-                  selectedPlotType: plotOption.label,
-                  selectedPlotOption: defaultPlotTypeAndParameterisation[plotOption.label],
-                  selectedPlotOptionLabel: Object.keys(defaultPlotTypeAndParameterisation[plotOption.label])[0]
-                      + ": " + Object.values(defaultPlotTypeAndParameterisation[plotOption.label])[0],
+                  selectedPlotType: plotOption.value,
+                  selectedPlotOption: defaultPlotTypeAndParameterisation[plotOption.value],
+                  selectedPlotOptionLabel: Object.keys(defaultPlotTypeAndParameterisation[plotOption.value])[0]
+                      + ": " + Object.values(defaultPlotTypeAndParameterisation[plotOption.value])[0],
                 })}
           }
           onChangePlotOptions={

--- a/packages/scxa-tsne-plot/html/Demo.js
+++ b/packages/scxa-tsne-plot/html/Demo.js
@@ -188,7 +188,7 @@ class Demo extends React.Component {
     return(
       <div className={`row column expanded`}>
         <TsnePlotView
-          atlasUrl={`http://localhost:8080/gxa/sc/`}
+          atlasUrl={`https://wwwdev.ebi.ac.uk:8080/gxa/sc/`}
           suggesterEndpoint={`json/suggestions`}
           experimentAccession={this.state.experimentAccession}
           accessKey={accessKey}

--- a/packages/scxa-tsne-plot/html/Demo.js
+++ b/packages/scxa-tsne-plot/html/Demo.js
@@ -91,6 +91,7 @@ const experiment6 = {
       label: `inferred cell type - ontology labels`
     }
   ],
+  defaultPlotTypeAndParameterisation: {"t-SNE": {"perplexity": 50}, "UMAP": {"n_neighbors": 100}},
   plotTypesAndOptions: {
     "tsne": [{ "perplexity": 40 }, { "perplexity": 25 }, { "perplexity": 45 },{ "perplexity": 1 },{ "perplexity": 30 },
     {"perplexity": 10 },{ "perplexity": 15 },{ "perplexity": 50 },{ "perplexity": 35 },{ "perplexity": 20 },{ "perplexity": 5 }],
@@ -119,7 +120,7 @@ const experimentOmega = {
   ]
 }
 
-const { accession, accessKey, ks, metadata, species, plotTypesAndOptions } = experiment6
+const { accession, accessKey, ks, metadata, species, plotTypesAndOptions, defaultPlotTypeAndParameterisation} = experiment6
 
 const plotTypeDropdown =  [
   {
@@ -127,7 +128,7 @@ const plotTypeDropdown =  [
     plotOptions: plotTypesAndOptions.umap
   },
   {
-    plotType: `tSNE`,
+    plotType: `t-SNE`,
     plotOptions: plotTypesAndOptions.tsne
   }
 ]
@@ -137,10 +138,10 @@ class Demo extends React.Component {
     super(props)
 
     this.state = {
-      selectedPlotType: plotTypeDropdown[0].plotType.toLowerCase(),
+      selectedPlotType: Object.keys(defaultPlotTypeAndParameterisation)[0],
       geneId: ``,
-      selectedPlotOption: Object.values(plotTypeDropdown[0].plotOptions[0])[0],
-      selectedPlotOptionLabel: Object.keys(plotTypeDropdown[0].plotOptions[0])[0] + `: ` + Object.values(plotTypeDropdown[0].plotOptions[0])[0],
+      selectedPlotOption: Object.values(Object.values(defaultPlotTypeAndParameterisation)[0])[0],
+      selectedPlotOptionLabel: Object.keys(Object.values(defaultPlotTypeAndParameterisation)[0])[0] + ": " + Object.values(Object.values(defaultPlotTypeAndParameterisation)[0])[0],
       selectedColourBy: ks[Math.round((ks.length -1) / 2)].toString(),
       highlightClusters: [],
       experimentAccession: accession,
@@ -187,7 +188,7 @@ class Demo extends React.Component {
     return(
       <div className={`row column expanded`}>
         <TsnePlotView
-          atlasUrl={`https://wwwdev.ebi.ac.uk/gxa/sc/`}
+          atlasUrl={`http://localhost:8080/gxa/sc/`}
           suggesterEndpoint={`json/suggestions`}
           experimentAccession={this.state.experimentAccession}
           accessKey={accessKey}
@@ -204,13 +205,10 @@ class Demo extends React.Component {
           onChangePlotTypes={
               (plotOption) => {
                 this.setState({
-                  selectedPlotType: plotOption,
-                  selectedPlotOption: Object.values(_find(plotTypeDropdown,
-                      (plot) => plot.plotType.toLowerCase() === plotOption).plotOptions[0])[0],
-                  selectedPlotOptionLabel: Object.keys(_find(plotTypeDropdown,
-                      (plot) => plot.plotType.toLowerCase() === plotOption).plotOptions[0])[0] + `: ` +
-                      Object.values(_find(plotTypeDropdown,
-                      (plot) => plot.plotType.toLowerCase() === plotOption).plotOptions[0])[0]
+                  selectedPlotType: plotOption.label,
+                  selectedPlotOption: defaultPlotTypeAndParameterisation[plotOption.label],
+                  selectedPlotOptionLabel: Object.keys(defaultPlotTypeAndParameterisation[plotOption.label])[0]
+                      + ": " + Object.values(defaultPlotTypeAndParameterisation[plotOption.label])[0],
                 })}
           }
           onChangePlotOptions={

--- a/packages/scxa-tsne-plot/src/TSnePlotView.js
+++ b/packages/scxa-tsne-plot/src/TSnePlotView.js
@@ -119,7 +119,7 @@ class TSnePlotView extends React.Component {
     const {loadingGeneExpression, geneExpressionData, geneExpressionErrorMessage} = this.state
     const {loadingCellClusters, cellClustersData, cellClustersErrorMessage} = this.state
 
-    const plot = _find(plotTypeDropdown, (plot) => plot.plotType.toLowerCase() === selectedPlotType)
+    const plot = _find(plotTypeDropdown, (plot) => plot.plotType.toLowerCase() === selectedPlotType.toLowerCase())
 
     const plotOptionsValues = plot.plotOptions.map((option) =>
       ({value: Object.values(option)[0], label: Object.keys(option)[0]+`: `+Object.values(option)[0]}))
@@ -156,7 +156,7 @@ class TSnePlotView extends React.Component {
                 options={plotTypesOptions}
                 defaultValue={{value: selectedPlotType, label: plot.plotType}}
                 onSelect={(selectedPlotType) => {
-                  onChangePlotTypes(selectedPlotType.value)
+                  onChangePlotTypes(selectedPlotType)
                 }}/>
           </div>
           <div className={`small-12 medium-6 columns`}>


### PR DESCRIPTION
We need to change these two methods:
- https://github.com/ebi-gene-expression-group/atlas-components/blob/9301396f596483e45946a16eb9c4cd7dd16e20af/packages/scxa-tsne-plot/src/TSnePlotView.js#L58
- https://github.com/ebi-gene-expression-group/atlas-components/blob/9301396f596483e45946a16eb9c4cd7dd16e20af/packages/scxa-tsne-plot/src/TSnePlotView.js#L80

Do not process the URL text outside of URI (e.g. https://github.com/ebi-gene-expression-group/atlas-components/blob/9301396f596483e45946a16eb9c4cd7dd16e20af/packages/scxa-tsne-plot/src/TSnePlotView.js#L67), you must use URI’s API to create the URL and the last method should always be .toString().

The endpoint for default plotTypes is provided in the PR https://github.com/ebi-gene-expression-group/atlas-web-single-cell/pull/272. I am trying to update the frontend component to apply this feature.