### PR TITLE
Add a visual UI distinction for anndata experiments in the experiments table

### DIFF
--- a/packages/atlas-experiment-table/__test__/TableCell.test.js
+++ b/packages/atlas-experiment-table/__test__/TableCell.test.js
@@ -63,6 +63,32 @@ describe(`TableCell`, () => {
     expect(wrapper.find(Table.Cell).find(`img`)).toHaveProp({src: `imageUrl`, alt: `altText`})
   })
 
+  test.each(
+      [`E-ANND-12`, `testExperimentAccession`, `E-MTAB-12`]
+  )(`is an image and check if it is an Anndata experiment or else`, (arrayDataKey) => {
+      const image = {
+            anndata: {
+              // tbc
+              src: `anndata image source`,
+              alt: `Anndata experiment`,
+              title: `Anndata experiment`
+            },
+            nonAnndata: {
+              src: `nonAnndata image source`,
+              alt: `Non-anndata experiment`,
+              title: `Non-anndata experiment`
+            }
+      }
+      props.dataRow.string = arrayDataKey
+    
+      const wrapper = shallow(<TableCell {...props} image={image} dataKey={`string`} />)
+0
+      expect(wrapper.find(Table.Cell)).toContainExactlyOneMatchingElement(`img`)
+      arrayDataKey.substring(0, 6) === `E-ANND` ? 
+          expect(wrapper.find(Table.Cell).find(`img`)).toHaveProp({src: `anndata image source`, alt: `Anndata experiment`}) :
+          expect(wrapper.find(Table.Cell).find(`img`)).toHaveProp({src: `nonAnndata image source`, alt: `Non-anndata experiment`})
+    })
+
   test(`defaults to a fallback icon if a suitable image can’t be found`, () => {
     const image = {}
     const wrapper = shallow(<TableCell {...props} image={image} dataKey={`string`}/>)

--- a/packages/atlas-experiment-table/__test__/experiments-sc.json
+++ b/packages/atlas-experiment-table/__test__/experiments-sc.json
@@ -1,5 +1,24 @@
 [
   {
+    "experimentAccession": "E-ANND-10",
+    "experimentDescription": "Single-cell transcriptome profiling for metastatic renal cell carcinoma patient-derived cells and xenografts",
+    "species": "Homo sapiens",
+    "kingdom": "animals",
+    "loadDate": "25-09-2019",
+    "lastUpdate": "25-09-2019",
+    "numberOfAssays": 118,
+    "rawExperimentType": "SINGLE_CELL_RNASEQ_MRNA_BASELINE",
+    "experimentType": "Baseline",
+    "technologyType": [
+      "smart-like"
+    ],
+    "experimentalFactors": [
+      "single cell identifier",
+      "growth condition"
+    ],
+    "experimentProjects": []
+  },
+  {
     "experimentAccession": "E-CURD-10",
     "experimentDescription": "Single-cell transcriptome profiling for metastatic renal cell carcinoma patient-derived cells and xenografts",
     "species": "Homo sapiens",

--- a/packages/atlas-experiment-table/html/index-sc.html
+++ b/packages/atlas-experiment-table/html/index-sc.html
@@ -31,6 +31,24 @@
         {
           tableHeaders: [
             {
+              label: 'Type',
+              dataKey: 'experimentAccession',
+              sortable: true,
+              width: 0.5,
+              image: {
+                  anndata: {
+                      src: 'https://www.ebi.ac.uk/gxa/resources/images/experiments-table/differential.png',
+                      alt: 'Anndata experiment',
+                      title: 'Anndata experiment'
+                  },
+                  nonAnndata: {
+                      src: 'https://www.ebi.ac.uk/gxa/resources/images/experiments-table/baseline.png',
+                      alt: 'Non-anndata experiment',
+                      title: 'Non-anndata experiment'
+                  }
+              }
+            },
+            {
               label: 'Load date',
               dataKey: 'loadDate',
               sortable: true,

--- a/packages/atlas-experiment-table/html/index-sc.html
+++ b/packages/atlas-experiment-table/html/index-sc.html
@@ -37,11 +37,13 @@
               width: 0.5,
               image: {
                   anndata: {
+                      //tbc, change the src accordingly
                       src: 'https://www.ebi.ac.uk/gxa/resources/images/experiments-table/differential.png',
                       alt: 'Anndata experiment',
                       title: 'Anndata experiment'
                   },
                   nonAnndata: {
+                      //tbc, change the src accordingly
                       src: 'https://www.ebi.ac.uk/gxa/resources/images/experiments-table/baseline.png',
                       alt: 'Non-anndata experiment',
                       title: 'Non-anndata experiment'

--- a/packages/atlas-experiment-table/src/TableCell.js
+++ b/packages/atlas-experiment-table/src/TableCell.js
@@ -11,6 +11,10 @@ const TableCell = ({ dataRow, dataKey, image, linkTo, host, width }) => {
     if (image[dataRow[dataKey]]) {
       cellItem = <img {...image[dataRow[dataKey]]}/>
     }
+    else if(Object.keys(image).includes(`anndata`)){
+      let ifAnndata = dataRow[dataKey].substring(0,6) === `E-ANND` ? `anndata` : `nonAnndata`
+      cellItem= <img {...image[ifAnndata]}/>
+    }
     else {
       cellItem = `❔`
     }

--- a/packages/atlas-experiment-table/src/TableCell.js
+++ b/packages/atlas-experiment-table/src/TableCell.js
@@ -6,13 +6,14 @@ import { Table, Text } from 'evergreen-ui'
 
 const TableCell = ({ dataRow, dataKey, image, linkTo, host, width }) => {
   let cellItem = null
+  let regex = new RegExp(`E-ANND`)
   if (image) {
     // If the column is an image put the image in the cell (or an unknown icon if the type is undefined)
     if (image[dataRow[dataKey]]) {
       cellItem = <img {...image[dataRow[dataKey]]}/>
     }
     else if (Object.keys(image).includes(`anndata`)) {
-      let ifAnndata = dataRow[dataKey].substring(0,6) === `E-ANND` ? `anndata` : `nonAnndata`
+      let ifAnndata = regex.test(dataRow[dataKey]) ? `anndata` : `nonAnndata`
       cellItem = <img {...image[ifAnndata]}/>
     }
     else {
@@ -21,30 +22,30 @@ const TableCell = ({ dataRow, dataKey, image, linkTo, host, width }) => {
   } else if (Array.isArray(dataRow[dataKey])) {
     // If the contents of the cell is an array expand it to a list
     cellItem =
-      <ul>
-        {dataRow[dataKey].map(
-          (element, index) =>
-            <li key={`${index}`}>
-              {element}
-            </li>
-        )}
-      </ul>
+        <ul>
+          {dataRow[dataKey].map(
+              (element, index) =>
+                  <li key={`${index}`}>
+                    {element}
+                  </li>
+          )}
+        </ul>
   } else {
     // Any other type (i.e. string, number) put it as-is in the cell
     cellItem = dataRow[dataKey]
   }
-  
+
   // Evergreen’s Table.TextCell ellipsifies content by default and we don’t want that
   return (
-    <Table.Cell flexGrow={width}>
-      <Text size={400}>
-        {
-          linkTo ?
-            <a href={URI(linkTo(dataRow), host).toString()}>{cellItem}</a> :
-            cellItem
-        }
-      </Text>
-    </Table.Cell>
+      <Table.Cell flexGrow={width}>
+        <Text size={400}>
+          {
+            linkTo ?
+                <a href={URI(linkTo(dataRow), host).toString()}>{cellItem}</a> :
+                cellItem
+          }
+        </Text>
+      </Table.Cell>
   )
 }
 
@@ -52,11 +53,11 @@ TableCell.propTypes = {
   dataRow: PropTypes.object.isRequired,
   dataKey: PropTypes.string.isRequired,
   image: PropTypes.objectOf(
-    PropTypes.shape({
-      src: PropTypes.string,
-      alt: PropTypes.string,
-      title: PropTypes.string
-    })
+      PropTypes.shape({
+        src: PropTypes.string,
+        alt: PropTypes.string,
+        title: PropTypes.string
+      })
   ),
   host: PropTypes.string,
   linkTo: PropTypes.func,

--- a/packages/atlas-experiment-table/src/TableCell.js
+++ b/packages/atlas-experiment-table/src/TableCell.js
@@ -11,9 +11,9 @@ const TableCell = ({ dataRow, dataKey, image, linkTo, host, width }) => {
     if (image[dataRow[dataKey]]) {
       cellItem = <img {...image[dataRow[dataKey]]}/>
     }
-    else if(Object.keys(image).includes(`anndata`)){
+    else if (Object.keys(image).includes(`anndata`)) {
       let ifAnndata = dataRow[dataKey].substring(0,6) === `E-ANND` ? `anndata` : `nonAnndata`
-      cellItem= <img {...image[ifAnndata]}/>
+      cellItem = <img {...image[ifAnndata]}/>
     }
     else {
       cellItem = `❔`


### PR DESCRIPTION
We add an icon column for experiment table to mark if it is anndata or not. We don't have a proper endpoint for anndata experiment type yet, so I pick the frontend solution. A jest test is added for the new feature.