### PR TITLE
Bugfix/colour by category url logic 400 error

### DIFF
--- a/packages/scxa-tsne-plot/html/Demo.js
+++ b/packages/scxa-tsne-plot/html/Demo.js
@@ -205,7 +205,7 @@ class Demo extends React.Component {
               (plotOption) => {
                 this.setState({
                   selectedPlotType: plotOption.value,
-                  selectedPlotOption: defaultPlotMethodAndParameterisation[plotOption.value],
+                  selectedPlotOption: Object.values(defaultPlotMethodAndParameterisation[plotOption.value])[0],
                   selectedPlotOptionLabel: Object.keys(defaultPlotMethodAndParameterisation[plotOption.value])[0]
                       + ": " + Object.values(defaultPlotMethodAndParameterisation[plotOption.value])[0],
                 })}

--- a/packages/scxa-tsne-plot/package-lock.json
+++ b/packages/scxa-tsne-plot/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@ebi-gene-expression-group/scxa-tsne-plot",
-	"version": "6.2.2",
+	"version": "6.3.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@ebi-gene-expression-group/scxa-tsne-plot",
-			"version": "6.1.0",
+			"version": "6.3.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@ebi-gene-expression-group/expression-atlas-autocomplete": "^3.2.4",

--- a/packages/scxa-tsne-plot/package.json
+++ b/packages/scxa-tsne-plot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/scxa-tsne-plot",
-  "version": "6.2.2",
+  "version": "6.3.0",
   "description": "A twin plot of metadata and gene expression to display t-SNE plots in Single Cell Expression Atlas",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/scxa-tsne-plot/src/TSnePlotView.js
+++ b/packages/scxa-tsne-plot/src/TSnePlotView.js
@@ -57,7 +57,7 @@ class TSnePlotView extends React.Component {
 
   _fetchAndSetStateCellClusters(
     {atlasUrl, experimentAccession, accessKey, selectedColourBy, selectedColourByCategory, selectedPlotType, selectedPlotOptionLabel}) {
-    const resource = selectedColourByCategory === `clusters` ?
+    const resource = !isNaN(selectedColourBy) ?
       URI(`json/cell-plots/${experimentAccession}/clusters/k/${selectedColourBy}`)
         .query({
           plotMethod: selectedPlotType,


### PR DESCRIPTION
I fix the logic in the url fetching stage, which is more straight forward, as the `colourByCategory` is decided by the vlaue of `colourBy`