### PR TITLE
418 updata anndata icon and title on scxa gene search and experiment table pages

### DIFF
--- a/packages/atlas-anatomogram-experiment-table/package-lock.json
+++ b/packages/atlas-anatomogram-experiment-table/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "anatomogramexperiment",
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/atlas-anatomogram-experiment-table/package.json
+++ b/packages/atlas-anatomogram-experiment-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anatomogramexperiment",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "",
   "main": "lib/anatomogramCellTypeHeatmapView.js",
   "scripts": {
@@ -14,7 +14,7 @@
     "url": "git+https://github.com/ebi-gene-expression-group/atlas-components.git"
   },
   "dependencies": {
-    "@ebi-gene-expression-group/atlas-experiment-table": "^3.2.5",
+    "@ebi-gene-expression-group/atlas-experiment-table": "^3.2.6",
     "@ebi-gene-expression-group/atlas-react-fetch-loader": "*",
     "@ebi-gene-expression-group/organ-anatomogram": "^1.0.0-beta1",
     "prop-types": "^15.7.2",

--- a/packages/atlas-experiment-table/package-lock.json
+++ b/packages/atlas-experiment-table/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ebi-gene-expression-group/atlas-experiment-table",
-	"version": "3.2.5",
+	"version": "3.2.6",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/atlas-experiment-table/package.json
+++ b/packages/atlas-experiment-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/atlas-experiment-table",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "description": "This package renders an experiment table with user interaction using Evergreen package",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/atlas-experiment-table/src/TableCell.js
+++ b/packages/atlas-experiment-table/src/TableCell.js
@@ -17,7 +17,7 @@ const TableCell = ({ label, dataRow, dataKey, image, linkTo, host, width }) => {
       <div className={'icon'}>
         {dataRow[dataKey]}
         <ExperimentIconDiv background={`indianred`} color={`white`} data-toggle={`tooltip`} data-placement={`bottom`}
-                         title={`Externally analysed data.`}>E</ExperimentIconDiv>
+                         title={`Externally analysed data`}>E</ExperimentIconDiv>
       </div>
   } else if (image) {
       // If the column is an image put the image in the cell (or an unknown icon if the type is undefined)

--- a/packages/atlas-experiment-table/src/TableCell.js
+++ b/packages/atlas-experiment-table/src/TableCell.js
@@ -17,7 +17,7 @@ const TableCell = ({ label, dataRow, dataKey, image, linkTo, host, width }) => {
       <div className={'icon'}>
         {dataRow[dataKey]}
         <ExperimentIconDiv background={`indianred`} color={`white`} data-toggle={`tooltip`} data-placement={`bottom`}
-                         title={`Experiment with annotated data analysed by an external source.`}>A</ExperimentIconDiv>
+                         title={`Externally analysed data.`}>E</ExperimentIconDiv>
       </div>
   } else if (image) {
       // If the column is an image put the image in the cell (or an unknown icon if the type is undefined)

--- a/packages/scxa-faceted-search-results/html/fetch-loader/ExperimentCard.js
+++ b/packages/scxa-faceted-search-results/html/fetch-loader/ExperimentCard.js
@@ -54,7 +54,7 @@ class ExperimentCard extends React.Component {
            {experimentDescription}
             <SmallIconDiv>
               {showIcon && <ExperimentIconDiv background={`indianred`} color={`white`} data-toggle={`tooltip`}
-                                  data-placement={`bottom`} title={`Externally analysed data.`}>E</ExperimentIconDiv>}
+                                  data-placement={`bottom`} title={`Externally analysed data`}>E</ExperimentIconDiv>}
             </SmallIconDiv>
        </TitleDiv>
         <VariableDiv>

--- a/packages/scxa-faceted-search-results/html/fetch-loader/ExperimentCard.js
+++ b/packages/scxa-faceted-search-results/html/fetch-loader/ExperimentCard.js
@@ -53,8 +53,8 @@ class ExperimentCard extends React.Component {
        <TitleDiv>
            {experimentDescription}
             <SmallIconDiv>
-              {showIcon && <ExperimentIconDiv background={`indianred`} color={`white`} data-toggle={`tooltip`} data-placement={`bottom`}
-                                              title={`Experiment with annotated data analysed by an external source.`}>A</ExperimentIconDiv>}
+              {showIcon && <ExperimentIconDiv background={`indianred`} color={`white`} data-toggle={`tooltip`}
+                                  data-placement={`bottom`} title={`Externally analysed data.`}>E</ExperimentIconDiv>}
             </SmallIconDiv>
        </TitleDiv>
         <VariableDiv>

--- a/packages/scxa-faceted-search-results/package-lock.json
+++ b/packages/scxa-faceted-search-results/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/scxa-faceted-search-results",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/scxa-faceted-search-results/package.json
+++ b/packages/scxa-faceted-search-results/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/scxa-faceted-search-results",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Icon changed from `A` to  `E`, and the tooltip text is  `Externally analysed data`.

