### PR TITLE
[bugfix] Set provided species parameter to GeneSearchForm

### DIFF
--- a/packages/scxa-cell-type-wheel-experiment-heatmap/cypress/component/CellTypeWheelExperimentHeatmap.cy.js
+++ b/packages/scxa-cell-type-wheel-experiment-heatmap/cypress/component/CellTypeWheelExperimentHeatmap.cy.js
@@ -93,12 +93,7 @@ describe(`CellTypeWheelExperimentHeatmap`, () => {
   })
 
   it(`species filter defaults to 'Any' if the species is not provided`, () => {
-    const cellType = `regulatory T cell`
-
     cy.intercept(`GET`, `/gxa/sc/json/suggestions/species`, speciesResponse)
-    cy.intercept(`GET`,
-      `/gxa/sc/json/cell-type-marker-genes/${URI(encodeURIComponent(cellType))}?experiment-accessions=E-ENAD-15`,
-      heatMapTCellResponse)
 
     cy.viewport(800, 1000)
     cy.mount(<CellTypeWheelExperimentHeatmap{...props}/>)
@@ -111,13 +106,9 @@ describe(`CellTypeWheelExperimentHeatmap`, () => {
   })
 
   it(`species filter defaults to 'Any' if the provided species variable is empty`, () => {
-    const cellType = `regulatory T cell`
     props.species = ``
 
     cy.intercept(`GET`, `/gxa/sc/json/suggestions/species`, speciesResponse)
-    cy.intercept(`GET`,
-      `/gxa/sc/json/cell-type-marker-genes/${URI(encodeURIComponent(cellType))}?experiment-accessions=E-ENAD-15`,
-      heatMapTCellResponse)
 
     cy.viewport(800, 1000)
     cy.mount(<CellTypeWheelExperimentHeatmap{...props}/>)
@@ -130,14 +121,10 @@ describe(`CellTypeWheelExperimentHeatmap`, () => {
   })
 
   it(`species filter selects the species value if it is provided`, () => {
-    const cellType = `regulatory T cell`
     const givenSpecies = `Mus musculus`
     props.species = givenSpecies
 
     cy.intercept(`GET`, `/gxa/sc/json/suggestions/species`, speciesResponse)
-    cy.intercept(`GET`,
-      `/gxa/sc/json/cell-type-marker-genes/${URI(encodeURIComponent(cellType))}?experiment-accessions=E-ENAD-15`,
-      heatMapTCellResponse)
 
     cy.viewport(800, 1000)
     cy.mount(<CellTypeWheelExperimentHeatmap{...props}/>)

--- a/packages/scxa-cell-type-wheel-experiment-heatmap/cypress/component/CellTypeWheelExperimentHeatmap.cy.js
+++ b/packages/scxa-cell-type-wheel-experiment-heatmap/cypress/component/CellTypeWheelExperimentHeatmap.cy.js
@@ -91,4 +91,61 @@ describe(`CellTypeWheelExperimentHeatmap`, () => {
       cell => cy.contains(cell.geneName)
     )
   })
+
+  it(`species filter defaults to 'Any' if the species is not provided`, () => {
+    const cellType = `regulatory T cell`
+
+    cy.intercept(`GET`, `/gxa/sc/json/suggestions/species`, speciesResponse)
+    cy.intercept(`GET`,
+      `/gxa/sc/json/cell-type-marker-genes/${URI(encodeURIComponent(cellType))}?experiment-accessions=E-ENAD-15`,
+      heatMapTCellResponse)
+
+    cy.viewport(800, 1000)
+    cy.mount(<CellTypeWheelExperimentHeatmap{...props}/>)
+
+    cy.get(`[data-cy='speciesDropDown']`)
+      .get(`div[class$='ValueContainer']`)
+      .last()
+      .invoke(`text`)
+      .should(`eq`, `Any`)
+  })
+
+  it(`species filter defaults to 'Any' if the provided species variable is empty`, () => {
+    const cellType = `regulatory T cell`
+    props.species = ``
+
+    cy.intercept(`GET`, `/gxa/sc/json/suggestions/species`, speciesResponse)
+    cy.intercept(`GET`,
+      `/gxa/sc/json/cell-type-marker-genes/${URI(encodeURIComponent(cellType))}?experiment-accessions=E-ENAD-15`,
+      heatMapTCellResponse)
+
+    cy.viewport(800, 1000)
+    cy.mount(<CellTypeWheelExperimentHeatmap{...props}/>)
+
+    cy.get(`[data-cy='speciesDropDown']`)
+      .get(`div[class$='ValueContainer']`)
+      .last()
+      .invoke(`text`)
+      .should(`eq`, `Any`)
+  })
+
+  it(`species filter selects the species value if it is provided`, () => {
+    const cellType = `regulatory T cell`
+    const givenSpecies = `Mus musculus`
+    props.species = givenSpecies
+
+    cy.intercept(`GET`, `/gxa/sc/json/suggestions/species`, speciesResponse)
+    cy.intercept(`GET`,
+      `/gxa/sc/json/cell-type-marker-genes/${URI(encodeURIComponent(cellType))}?experiment-accessions=E-ENAD-15`,
+      heatMapTCellResponse)
+
+    cy.viewport(800, 1000)
+    cy.mount(<CellTypeWheelExperimentHeatmap{...props}/>)
+
+    cy.get(`[data-cy='speciesDropDown']`)
+      .get(`div[class$='ValueContainer']`)
+      .last()
+      .invoke(`text`)
+      .should(`eq`, givenSpecies)
+  })
 })

--- a/packages/scxa-cell-type-wheel-experiment-heatmap/package.json
+++ b/packages/scxa-cell-type-wheel-experiment-heatmap/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@ebi-gene-expression-group/atlas-react-fetch-loader": "*",
     "@ebi-gene-expression-group/scxa-cell-type-wheel": "^1.1.4",
-    "@ebi-gene-expression-group/scxa-gene-search-form": "*",
+    "@ebi-gene-expression-group/scxa-gene-search-form": "^2.0.1",
     "@ebi-gene-expression-group/scxa-marker-gene-heatmap": "*",
     "highcharts": "^10.1.0",
     "highcharts-react-official": "^3.1.0",

--- a/packages/scxa-cell-type-wheel-experiment-heatmap/package.json
+++ b/packages/scxa-cell-type-wheel-experiment-heatmap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/scxa-cell-type-wheel-heatmap",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/scxa-cell-type-wheel-experiment-heatmap/src/CellTypeWheelExperimentHeatmap.js
+++ b/packages/scxa-cell-type-wheel-experiment-heatmap/src/CellTypeWheelExperimentHeatmap.js
@@ -48,13 +48,18 @@ function CellTypeWheelExperimentHeatmap(props) {
         defaultValue={ { term: props.searchTerm, category: `metadata` } }
         enableSpeciesSelect={true}
         speciesSelectClassName={`small-4 columns`}
+        defaultSpecies={props.species}
       />
       <div className={`row-expanded small-12 columns`}>
         <div className={`small-12 medium-6 columns`} aria-label={`Cell type wheel`}>
           {props.searchTerm.trim() ?
             <CellTypeWheelFetchLoader
               host={props.host}
-              resource={URI(props.searchTerm, props.cellTypeWheelResource).toString()}
+              resource={URI(props.cellTypeWheelResource)
+                .segment(props.searchTerm)
+                .search(`?species=` + props.species)
+                .toString()
+              }
               fulfilledPayloadProvider={cellTypeWheelData => ({ data: cellTypeWheelData })}
               searchTerm={props.searchTerm}
               onCellTypeWheelClick={onCellTypeWheelClick}
@@ -99,7 +104,8 @@ CellTypeWheelExperimentHeatmap.propTypes = {
   suggesterEndpoint: PropTypes.string,
   cellTypeWheelResource: PropTypes.string,
   heatmapResource: PropTypes.string,
-  searchTerm: PropTypes.string.isRequired
+  searchTerm: PropTypes.string.isRequired,
+  species: PropTypes.string
 }
 
 CellTypeWheelExperimentHeatmap.defaultProps = {

--- a/packages/scxa-gene-search-form/package.json
+++ b/packages/scxa-gene-search-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/scxa-gene-search-form",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Single Cell Expression Atlas homepage gene search form",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/scxa-gene-search-form/src/GeneSearchForm.js
+++ b/packages/scxa-gene-search-form/src/GeneSearchForm.js
@@ -52,7 +52,7 @@ class GeneSearchForm extends React.Component {
     return (
       <form action={URI(actionEndpoint, host).toString()} method={`post`}>
         <div className={wrapperClassName}>
-          <div className={autocompleteClassName}>
+          <div className={autocompleteClassName} data-cy={`searchTerm`}>
             <Autocomplete
               host={host}
               suggesterEndpoint={suggesterEndpoint}
@@ -63,9 +63,9 @@ class GeneSearchForm extends React.Component {
               labelText={autocompleteLabel}/>
           </div>
           { enableSpeciesSelect &&
-            <div className={speciesSelectClassName}>
+            <div className={speciesSelectClassName} data-cy={`speciesDropDown`}>
               <LabelledSelect
-                name={`species`}
+                name={`speciesDropDown`}
                 topGroup={topSpecies}
                 bottomGroup={allSpecies}
                 bottomGroupLabel={`All species`}

--- a/packages/scxa-gene-search-form/src/GeneSearchForm.js
+++ b/packages/scxa-gene-search-form/src/GeneSearchForm.js
@@ -65,7 +65,7 @@ class GeneSearchForm extends React.Component {
           { enableSpeciesSelect &&
             <div className={speciesSelectClassName} data-cy={`speciesDropDown`}>
               <LabelledSelect
-                name={`speciesDropDown`}
+                name={`species`}
                 topGroup={topSpecies}
                 bottomGroup={allSpecies}
                 bottomGroupLabel={`All species`}


### PR DESCRIPTION
Species parameter was ignored when it was provided as a URL request parameter.
With this change I set the species parameter on the `GeneSearchForm` and also pass it to the `CellTypeWheelFetchLoader`.
I also added 3 new test cases to cover these cases.