### PR TITLE
Cell plots ks are not always required for anndata experiments

### DIFF
--- a/packages/atlas-anatomogram-experiment-table/package-lock.json
+++ b/packages/atlas-anatomogram-experiment-table/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "anatomogramexperiment",
-	"version": "1.1.6",
+	"version": "1.1.7",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/atlas-anatomogram-experiment-table/package.json
+++ b/packages/atlas-anatomogram-experiment-table/package.json
@@ -48,5 +48,5 @@
     "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^3.11.0"
   },
-  "gitHead": "3c3e8c8de82cbcd35fef05db76775e04f7f24289"
+  "gitHead": "0fcac2cf1b51445c92c92a4dc4ce51f468a1a6fb"
 }

--- a/packages/atlas-anatomogram-experiment-table/package.json
+++ b/packages/atlas-anatomogram-experiment-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anatomogramexperiment",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "",
   "main": "lib/anatomogramCellTypeHeatmapView.js",
   "scripts": {
@@ -14,7 +14,7 @@
     "url": "git+https://github.com/ebi-gene-expression-group/atlas-components.git"
   },
   "dependencies": {
-    "@ebi-gene-expression-group/atlas-experiment-table": "^3.2.8",
+    "@ebi-gene-expression-group/atlas-experiment-table": "^3.2.9",
     "@ebi-gene-expression-group/atlas-react-fetch-loader": "*",
     "@ebi-gene-expression-group/organ-anatomogram": "^1.0.0-beta1",
     "prop-types": "^15.7.2",

--- a/packages/atlas-experiment-table/package-lock.json
+++ b/packages/atlas-experiment-table/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ebi-gene-expression-group/atlas-experiment-table",
-	"version": "3.2.8",
+	"version": "3.2.9",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/atlas-experiment-table/package.json
+++ b/packages/atlas-experiment-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/atlas-experiment-table",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "description": "This package renders an experiment table with user interaction using Evergreen package",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/atlas-experiment-table/package.json
+++ b/packages/atlas-experiment-table/package.json
@@ -73,5 +73,5 @@
     "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^3.11.0"
   },
-  "gitHead": "3c3e8c8de82cbcd35fef05db76775e04f7f24289"
+  "gitHead": "0fcac2cf1b51445c92c92a4dc4ce51f468a1a6fb"
 }

--- a/packages/scxa-cell-type-wheel-experiment-heatmap/package-lock.json
+++ b/packages/scxa-cell-type-wheel-experiment-heatmap/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/scxa-cell-type-wheel-heatmap",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/scxa-cell-type-wheel-experiment-heatmap/package.json
+++ b/packages/scxa-cell-type-wheel-experiment-heatmap/package.json
@@ -60,5 +60,5 @@
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^4.15.1"
   },
-  "gitHead": "3c3e8c8de82cbcd35fef05db76775e04f7f24289"
+  "gitHead": "0fcac2cf1b51445c92c92a4dc4ce51f468a1a6fb"
 }

--- a/packages/scxa-cell-type-wheel-experiment-heatmap/package.json
+++ b/packages/scxa-cell-type-wheel-experiment-heatmap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/scxa-cell-type-wheel-heatmap",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "publishConfig": {
     "access": "public"
   },
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "@ebi-gene-expression-group/atlas-react-fetch-loader": "*",
-    "@ebi-gene-expression-group/scxa-cell-type-wheel": "^1.1.7",
-    "@ebi-gene-expression-group/scxa-gene-search-form": "^2.0.5",
+    "@ebi-gene-expression-group/scxa-cell-type-wheel": "^1.1.8",
+    "@ebi-gene-expression-group/scxa-gene-search-form": "^2.0.6",
     "@ebi-gene-expression-group/scxa-marker-gene-heatmap": "*",
     "highcharts": "^11.4.6",
     "highcharts-react-official": "^3.2.1",

--- a/packages/scxa-cell-type-wheel/package-lock.json
+++ b/packages/scxa-cell-type-wheel/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/scxa-cell-type-wheel",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/scxa-cell-type-wheel/package.json
+++ b/packages/scxa-cell-type-wheel/package.json
@@ -49,5 +49,5 @@
     "webpack": "^5.73.0",
     "webpack-dev-server": "^4.9.2"
   },
-  "gitHead": "3c3e8c8de82cbcd35fef05db76775e04f7f24289"
+  "gitHead": "0fcac2cf1b51445c92c92a4dc4ce51f468a1a6fb"
 }

--- a/packages/scxa-cell-type-wheel/package.json
+++ b/packages/scxa-cell-type-wheel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/scxa-cell-type-wheel",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/scxa-faceted-search-results/package-lock.json
+++ b/packages/scxa-faceted-search-results/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/scxa-faceted-search-results",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/scxa-faceted-search-results/package.json
+++ b/packages/scxa-faceted-search-results/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/scxa-faceted-search-results",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/scxa-faceted-search-results/package.json
+++ b/packages/scxa-faceted-search-results/package.json
@@ -72,5 +72,5 @@
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.11.1"
   },
-  "gitHead": "3c3e8c8de82cbcd35fef05db76775e04f7f24289"
+  "gitHead": "0fcac2cf1b51445c92c92a4dc4ce51f468a1a6fb"
 }

--- a/packages/scxa-gene-search-form/package-lock.json
+++ b/packages/scxa-gene-search-form/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/scxa-gene-search-form",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/scxa-gene-search-form/package.json
+++ b/packages/scxa-gene-search-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/scxa-gene-search-form",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Single Cell Expression Atlas homepage gene search form",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/scxa-gene-search-form/package.json
+++ b/packages/scxa-gene-search-form/package.json
@@ -55,5 +55,5 @@
     "webpack-dev-server": "^4.9.2",
     "whatwg-fetch": "^3.6.2"
   },
-  "gitHead": "3c3e8c8de82cbcd35fef05db76775e04f7f24289"
+  "gitHead": "0fcac2cf1b51445c92c92a4dc4ce51f468a1a6fb"
 }

--- a/packages/scxa-tsne-plot/__test__/ClusterTSnePlot.test.js
+++ b/packages/scxa-tsne-plot/__test__/ClusterTSnePlot.test.js
@@ -183,6 +183,22 @@ describe(`ClusterTSnePlot`, () => {
     expect(dropdown.props().defaultValue.label).toContain(`The first metadata value`)
   })
 
+  test(`dropdown selection text only have metadata if ks is empty`, () => {
+    const ks = []
+    const metadata = [
+      {
+        value: `metadata-1`,
+        label: `The first metadata value`
+      }
+    ]
+
+    const wrapper = mount(<ClusterTSnePlot {...props} ks={ks} metadata={metadata} selectedColourBy={`metadata-1`} selectedColourCategory={`metadata`} showControls={true}/>)
+
+    const dropdown = wrapper.find({ labelText: `Colour plot by:`})
+
+    expect(dropdown.props()).not.toContain(`NUMBER OF CLUSTERS`)
+  })
+
   test(`hides the cluster name in tooltips if tSNE is coloured by metadata`, () => {
     const randomSeries1 = randomHighchartsSeriesWithNamesAndMaxPoints(seriesNames, 10).map(point => Object.assign(point, {clusterType: `clusters`}))
     const randomSeries2 = randomHighchartsSeriesWithNamesAndMaxPoints(seriesNames, 10).map(point => Object.assign(point, {clusterType: `metadata`}))

--- a/packages/scxa-tsne-plot/html/Demo.js
+++ b/packages/scxa-tsne-plot/html/Demo.js
@@ -141,7 +141,7 @@ class Demo extends React.Component {
       geneId: ``,
       selectedPlotOption: Object.values(Object.values(defaultPlotMethodAndParameterisation)[0])[0],
       selectedPlotOptionLabel: Object.keys(Object.values(defaultPlotMethodAndParameterisation)[0])[0] + ": " + Object.values(Object.values(defaultPlotMethodAndParameterisation)[0])[0],
-      selectedColourBy: ks[Math.round((ks.length -1) / 2)].toString(),
+      selectedColourBy: metadata ? metadata[0].value : ``, //ks may be empty, we prefer metadata as the default option
       highlightClusters: [],
       experimentAccession: accession,
       selectedColourByCategory: `clusters`

--- a/packages/scxa-tsne-plot/package-lock.json
+++ b/packages/scxa-tsne-plot/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ebi-gene-expression-group/scxa-tsne-plot",
-	"version": "6.3.2",
+	"version": "6.3.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/scxa-tsne-plot/package.json
+++ b/packages/scxa-tsne-plot/package.json
@@ -81,5 +81,5 @@
     "webpack-dev-server": "^3.11.0",
     "whatwg-fetch": "^3.4.0"
   },
-  "gitHead": "3c3e8c8de82cbcd35fef05db76775e04f7f24289"
+  "gitHead": "0fcac2cf1b51445c92c92a4dc4ce51f468a1a6fb"
 }

--- a/packages/scxa-tsne-plot/package.json
+++ b/packages/scxa-tsne-plot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/scxa-tsne-plot",
-  "version": "6.3.2",
+  "version": "6.3.3",
   "description": "A twin plot of metadata and gene expression to display t-SNE plots in Single Cell Expression Atlas",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/scxa-tsne-plot/src/ClusterTSnePlot.js
+++ b/packages/scxa-tsne-plot/src/ClusterTSnePlot.js
@@ -118,11 +118,11 @@ const ClusterTSnePlot = (props) => {
     }
   }
 
-  const kOptions = ks.sort((a, b) => a - b).map((k) => ({
+  const kOptions = ks.length > 0 ? ks.sort((a, b) => a - b).map((k) => ({
     value: k.toString(),
     label: `k = ${k}`,
     group: `clusters`
-  }))
+  })) : null
 
   const metadataOptions = metadata.map((metadata) => ({
     ...metadata,
@@ -133,12 +133,15 @@ const ClusterTSnePlot = (props) => {
     {
       label: `Metadata`,
       options: metadataOptions,
-    },
-    {
+    }
+  ]
+
+  if (kOptions) {
+    options[1] = {
       label: `Number of clusters`,
       options: kOptions,
-    },
-  ]
+    }
+  }
 
   const defaultValue = _find(
       _flatten(

--- a/packages/scxa-tsne-widget/package-lock.json
+++ b/packages/scxa-tsne-widget/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ebi-gene-expression-group/scxa-tsne-widget",
-	"version": "2.3.5",
+	"version": "2.3.6",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/scxa-tsne-widget/package.json
+++ b/packages/scxa-tsne-widget/package.json
@@ -61,5 +61,5 @@
     "webpack-dev-server": "^3.11.0",
     "whatwg-fetch": "^3.4.0"
   },
-  "gitHead": "3c3e8c8de82cbcd35fef05db76775e04f7f24289"
+  "gitHead": "0fcac2cf1b51445c92c92a4dc4ce51f468a1a6fb"
 }

--- a/packages/scxa-tsne-widget/package.json
+++ b/packages/scxa-tsne-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/scxa-tsne-widget",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "description": "tSNE widget visualizes Single Cell Expression Atlas data",
   "main": "lib/index.js",
   "scripts": {
@@ -35,7 +35,7 @@
     "url": "git+https://github.com/ebi-gene-expression-group/atlas-components.git"
   },
   "dependencies": {
-    "@ebi-gene-expression-group/scxa-tsne-plot": "^6.3.2",
+    "@ebi-gene-expression-group/scxa-tsne-plot": "^6.3.3",
     "expression-atlas-autocomplete": "^3.2.0",
     "prop-types": "^15.7.2",
     "react": "^17.0.0",


### PR DESCRIPTION
In this example experiment page, https://www-test.ebi.ac.uk/gxa/sc/experiments/E-ANND-3/results/, `ks` is empty, i.e. `ks=[]` in the page content, so we need to make a new feature in the tsne plot, to handle this case.