### PR TITLE
Add external data help page hyperlink

### DIFF
--- a/packages/atlas-experiment-table/html/index-sc.html
+++ b/packages/atlas-experiment-table/html/index-sc.html
@@ -116,7 +116,7 @@
             width: 0.5
           },
           dataRows: data,
-          host: 'https://www.ebi.ac.uk/gxa/sc/'
+          host: 'http://localhost:8080/gxa/sc/'
         },
         'target'
       );

--- a/packages/atlas-experiment-table/src/TableCell.js
+++ b/packages/atlas-experiment-table/src/TableCell.js
@@ -16,8 +16,11 @@ const TableCell = ({ label, dataRow, dataKey, image, linkTo, host, width }) => {
     cellItem =
       <div className={'icon'}>
         {dataRow[dataKey]}
-        <ExperimentIconDiv background={`indianred`} color={`white`} data-toggle={`tooltip`} data-placement={`bottom`}
-                         title={`Externally analysed data`}>E</ExperimentIconDiv>
+          <a href={`${host}/help.html?section=external-data`}>
+              <ExperimentIconDiv background={`indianred`} color={`white`} data-toggle={`tooltip`} data-placement={`bottom`}
+                                 title={`Externally analysed data`}>E</ExperimentIconDiv>
+          </a>
+
       </div>
   } else if (image) {
       // If the column is an image put the image in the cell (or an unknown icon if the type is undefined)


### PR DESCRIPTION
Given the commits to help page repo by Silvie, and the backend PR https://github.com/ebi-gene-expression-group/atlas-web-single-cell/pull/459  implemented, the link is `http://localhost:8080/gxa/sc/help.html?section=external-data` .

We may need to publish a new package version for atlas-experiment-table component and integrate into the backend PR.