### PR TITLE
scxa-cell-type-wheel-experiment-heatmap/bugfix/encode-slash-for-cell-type

### DIFF
--- a/packages/scxa-cell-type-wheel-experiment-heatmap/cypress/component/CellTypeWheelExperimentHeatmap.cy.js
+++ b/packages/scxa-cell-type-wheel-experiment-heatmap/cypress/component/CellTypeWheelExperimentHeatmap.cy.js
@@ -48,7 +48,7 @@ describe(`CellTypeWheelExperimentHeatmap`, () => {
     const cellType = `regulatory T cell`
     cy.intercept(`GET`, `/gxa/sc/json/suggestions/species`,
       speciesResponse)
-    cy.intercept(`GET`, `/gxa/sc/json/cell-type-marker-genes/${URI(encodeURIComponent(base64_encode(cellType)))}?experiment-accessions=E-ENAD-15`,
+    cy.intercept(`GET`, `/gxa/sc/json/cell-type-marker-genes/${URI(base64_encode(cellType))}?experiment-accessions=E-ENAD-15`,
       heatMapTCellResponse)
     cy.viewport(800, 1000)
     cy.mount(<CellTypeWheelExperimentHeatmap

--- a/packages/scxa-cell-type-wheel-experiment-heatmap/cypress/component/CellTypeWheelExperimentHeatmap.cy.js
+++ b/packages/scxa-cell-type-wheel-experiment-heatmap/cypress/component/CellTypeWheelExperimentHeatmap.cy.js
@@ -5,6 +5,7 @@ import speciesResponse from '../fixtures/speciesResponse.json'
 import cellTypeWheelData from '../fixtures/CellTypeDataForWheelResponse.json'
 import heatMapTCellResponse from '../fixtures/heatMapRegulatoryTCellResponse.json'
 import URI from 'urijs'
+import {decode as base64_decode, encode as base64_encode} from 'base-64';
 
 function firstWordMatcherOf(str) {
   return new RegExp(`.${str.split(` `)[0]}*`)
@@ -47,7 +48,7 @@ describe(`CellTypeWheelExperimentHeatmap`, () => {
     const cellType = `regulatory T cell`
     cy.intercept(`GET`, `/gxa/sc/json/suggestions/species`,
       speciesResponse)
-    cy.intercept(`GET`, `/gxa/sc/json/cell-type-marker-genes/${URI(encodeURIComponent(cellType))}?experiment-accessions=E-ENAD-15`,
+    cy.intercept(`GET`, `/gxa/sc/json/cell-type-marker-genes/${URI(encodeURIComponent(base64_encode(cellType)))}?experiment-accessions=E-ENAD-15`,
       heatMapTCellResponse)
     cy.viewport(800, 1000)
     cy.mount(<CellTypeWheelExperimentHeatmap
@@ -62,7 +63,7 @@ describe(`CellTypeWheelExperimentHeatmap`, () => {
     const cellType = `regulatory T cell`
     cy.intercept(`GET`, `/gxa/sc/json/suggestions/species`,
       speciesResponse)
-    cy.intercept(`GET`, `/gxa/sc/json/cell-type-marker-genes/${URI(encodeURIComponent(cellType))}?experiment-accessions=E-ENAD-15`,
+    cy.intercept(`GET`, `/gxa/sc/json/cell-type-marker-genes/${URI(base64_encode(cellType))}?experiment-accessions=E-ENAD-15`,
       heatMapTCellResponse)
     cy.viewport(800, 1000)
     cy.mount(<CellTypeWheelExperimentHeatmap
@@ -79,7 +80,7 @@ describe(`CellTypeWheelExperimentHeatmap`, () => {
     const cellTypeWithSlash = `mucosal invariant / T cell`
     cy.intercept(`GET`, `/gxa/sc/json/suggestions/species`,
       speciesResponse)
-    cy.intercept(`GET`, `/gxa/sc/json/cell-type-marker-genes/${URI(encodeURIComponent(cellTypeWithSlash))}?experiment-accessions=E-MTAB-7704`,
+    cy.intercept(`GET`, `/gxa/sc/json/cell-type-marker-genes/${URI(base64_encode(cellTypeWithSlash))}?experiment-accessions=E-MTAB-7704`,
       heatMapTCellResponse)
     cy.viewport(800, 1000)
     cy.mount(<CellTypeWheelExperimentHeatmap

--- a/packages/scxa-cell-type-wheel-experiment-heatmap/cypress/component/CellTypeWheelExperimentHeatmap.cy.js
+++ b/packages/scxa-cell-type-wheel-experiment-heatmap/cypress/component/CellTypeWheelExperimentHeatmap.cy.js
@@ -5,7 +5,7 @@ import speciesResponse from '../fixtures/speciesResponse.json'
 import cellTypeWheelData from '../fixtures/CellTypeDataForWheelResponse.json'
 import heatMapTCellResponse from '../fixtures/heatMapRegulatoryTCellResponse.json'
 import URI from 'urijs'
-import {decode as base64_decode, encode as base64_encode} from 'base-64';
+import { encode as base64Encode } from 'base-64';
 
 function firstWordMatcherOf(str) {
   return new RegExp(`.${str.split(` `)[0]}*`)
@@ -48,7 +48,7 @@ describe(`CellTypeWheelExperimentHeatmap`, () => {
     const cellType = `regulatory T cell`
     cy.intercept(`GET`, `/gxa/sc/json/suggestions/species`,
       speciesResponse)
-    cy.intercept(`GET`, `/gxa/sc/json/cell-type-marker-genes/${URI(base64_encode(cellType))}?experiment-accessions=E-ENAD-15`,
+    cy.intercept(`GET`, `/gxa/sc/json/cell-type-marker-genes/${URI(base64Encode(cellType))}?experiment-accessions=E-ENAD-15`,
       heatMapTCellResponse)
     cy.viewport(800, 1000)
     cy.mount(<CellTypeWheelExperimentHeatmap
@@ -63,7 +63,7 @@ describe(`CellTypeWheelExperimentHeatmap`, () => {
     const cellType = `regulatory T cell`
     cy.intercept(`GET`, `/gxa/sc/json/suggestions/species`,
       speciesResponse)
-    cy.intercept(`GET`, `/gxa/sc/json/cell-type-marker-genes/${URI(base64_encode(cellType))}?experiment-accessions=E-ENAD-15`,
+    cy.intercept(`GET`, `/gxa/sc/json/cell-type-marker-genes/${URI(base64Encode(cellType))}?experiment-accessions=E-ENAD-15`,
       heatMapTCellResponse)
     cy.viewport(800, 1000)
     cy.mount(<CellTypeWheelExperimentHeatmap
@@ -80,7 +80,7 @@ describe(`CellTypeWheelExperimentHeatmap`, () => {
     const cellTypeWithSlash = `mucosal invariant / T cell`
     cy.intercept(`GET`, `/gxa/sc/json/suggestions/species`,
       speciesResponse)
-    cy.intercept(`GET`, `/gxa/sc/json/cell-type-marker-genes/${URI(base64_encode(cellTypeWithSlash))}?experiment-accessions=E-MTAB-7704`,
+    cy.intercept(`GET`, `/gxa/sc/json/cell-type-marker-genes/${URI(base64Encode(cellTypeWithSlash))}?experiment-accessions=E-MTAB-7704`,
       heatMapTCellResponse)
     cy.viewport(800, 1000)
     cy.mount(<CellTypeWheelExperimentHeatmap

--- a/packages/scxa-cell-type-wheel-experiment-heatmap/package-lock.json
+++ b/packages/scxa-cell-type-wheel-experiment-heatmap/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/scxa-cell-type-wheel-heatmap",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/scxa-cell-type-wheel-experiment-heatmap/package-lock.json
+++ b/packages/scxa-cell-type-wheel-experiment-heatmap/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/scxa-cell-type-wheel-heatmap",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/scxa-cell-type-wheel-experiment-heatmap/package.json
+++ b/packages/scxa-cell-type-wheel-experiment-heatmap/package.json
@@ -35,7 +35,8 @@
     "prop-types": "^15.8.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "urijs": "^1.19.11"
+    "urijs": "^1.19.11",
+    "base-64": "^1.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.17.10",

--- a/packages/scxa-cell-type-wheel-experiment-heatmap/package.json
+++ b/packages/scxa-cell-type-wheel-experiment-heatmap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/scxa-cell-type-wheel-heatmap",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "publishConfig": {
     "access": "public"
   },
@@ -29,14 +29,14 @@
     "@ebi-gene-expression-group/scxa-cell-type-wheel": "^1.1.10",
     "@ebi-gene-expression-group/scxa-gene-search-form": "^2.1.0",
     "@ebi-gene-expression-group/scxa-marker-gene-heatmap": "^2.6.0",
+    "base-64": "^1.0.0",
     "highcharts": "^11.4.6",
     "highcharts-react-official": "^3.2.1",
     "lodash": "^4.17.21",
     "prop-types": "^15.8.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "urijs": "^1.19.11",
-    "base-64": "^1.0.0"
+    "urijs": "^1.19.11"
   },
   "devDependencies": {
     "@babel/cli": "^7.17.10",

--- a/packages/scxa-cell-type-wheel-experiment-heatmap/package.json
+++ b/packages/scxa-cell-type-wheel-experiment-heatmap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/scxa-cell-type-wheel-heatmap",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/scxa-cell-type-wheel-experiment-heatmap/src/CellTypeWheelExperimentHeatmap.js
+++ b/packages/scxa-cell-type-wheel-experiment-heatmap/src/CellTypeWheelExperimentHeatmap.js
@@ -103,7 +103,7 @@ function CellTypeWheelExperimentHeatmap(props) {
           {heatmapSelection.cellType ?
             <MarkerGeneHeatmapFetchLoader
               host={props.host}
-              resource={URI(encodeURIComponent(heatmapSelection.cellType), props.heatmapResource).toString()}
+              resource={URI(props.heatmapResource).segment(encodeURIComponent(btoa(heatmapSelection.cellType))).toString()}
               fulfilledPayloadProvider={heatmapFulfilledPayloadProvider}
               query={{ [`experiment-accessions`]: heatmapSelection.experimentAccessions }}
               cellType={heatmapSelection.cellType}

--- a/packages/scxa-cell-type-wheel-experiment-heatmap/src/CellTypeWheelExperimentHeatmap.js
+++ b/packages/scxa-cell-type-wheel-experiment-heatmap/src/CellTypeWheelExperimentHeatmap.js
@@ -8,6 +8,7 @@ import { withFetchLoader } from '@ebi-gene-expression-group/atlas-react-fetch-lo
 import CellTypeWheel from '@ebi-gene-expression-group/scxa-cell-type-wheel'
 import MarkerGeneHeatmap from '@ebi-gene-expression-group/scxa-marker-gene-heatmap/lib/MarkerGeneHeatmap'
 import GeneSearchForm from '@ebi-gene-expression-group/scxa-gene-search-form'
+import {encode as base64_encode} from 'base-64'
 
 const CellTypeWheelFetchLoader = withFetchLoader(CellTypeWheel)
 const MarkerGeneHeatmapFetchLoader = withFetchLoader(MarkerGeneHeatmap)
@@ -103,7 +104,8 @@ function CellTypeWheelExperimentHeatmap(props) {
           {heatmapSelection.cellType ?
             <MarkerGeneHeatmapFetchLoader
               host={props.host}
-              resource={URI(props.heatmapResource).segment(encodeURIComponent(btoa(heatmapSelection.cellType))).toString()}
+              resource={URI(props.heatmapResource)
+                        .segmentCoded(base64_encode(heatmapSelection.cellType)).toString()}
               fulfilledPayloadProvider={heatmapFulfilledPayloadProvider}
               query={{ [`experiment-accessions`]: heatmapSelection.experimentAccessions }}
               cellType={heatmapSelection.cellType}
@@ -142,7 +144,7 @@ CellTypeWheelExperimentHeatmap.defaultProps = {
   actionEndpoint: `search`,
   suggesterEndpoint: `json/suggestions/gene_ids`,
   cellTypeWheelResource: `json/cell-type-wheel/`,
-  heatmapResource: `json/cell-type-marker-genes/`
+  heatmapResource: `json/cell-type-marker-genes/`,
 }
 
 export default CellTypeWheelExperimentHeatmap

--- a/packages/scxa-cell-type-wheel-experiment-heatmap/src/CellTypeWheelExperimentHeatmap.js
+++ b/packages/scxa-cell-type-wheel-experiment-heatmap/src/CellTypeWheelExperimentHeatmap.js
@@ -8,7 +8,7 @@ import { withFetchLoader } from '@ebi-gene-expression-group/atlas-react-fetch-lo
 import CellTypeWheel from '@ebi-gene-expression-group/scxa-cell-type-wheel'
 import MarkerGeneHeatmap from '@ebi-gene-expression-group/scxa-marker-gene-heatmap/lib/MarkerGeneHeatmap'
 import GeneSearchForm from '@ebi-gene-expression-group/scxa-gene-search-form'
-import {encode as base64_encode} from 'base-64'
+import { encode as base64Encode } from 'base-64'
 
 const CellTypeWheelFetchLoader = withFetchLoader(CellTypeWheel)
 const MarkerGeneHeatmapFetchLoader = withFetchLoader(MarkerGeneHeatmap)
@@ -105,7 +105,7 @@ function CellTypeWheelExperimentHeatmap(props) {
             <MarkerGeneHeatmapFetchLoader
               host={props.host}
               resource={URI(props.heatmapResource)
-                        .segmentCoded(base64_encode(heatmapSelection.cellType)).toString()}
+                        .segmentCoded(base64Encode(heatmapSelection.cellType)).toString()}
               fulfilledPayloadProvider={heatmapFulfilledPayloadProvider}
               query={{ [`experiment-accessions`]: heatmapSelection.experimentAccessions }}
               cellType={heatmapSelection.cellType}
@@ -144,7 +144,7 @@ CellTypeWheelExperimentHeatmap.defaultProps = {
   actionEndpoint: `search`,
   suggesterEndpoint: `json/suggestions/gene_ids`,
   cellTypeWheelResource: `json/cell-type-wheel/`,
-  heatmapResource: `json/cell-type-marker-genes/`,
+  heatmapResource: `json/cell-type-marker-genes/`
 }
 
 export default CellTypeWheelExperimentHeatmap


### PR DESCRIPTION
Fix for the front end(web app) and backend endpoint (API) to accept / in the cell type 

Endpoint `- /json/cell-type-marker-genes/{cellType}`