### PR TITLE
173 overlapping names in the marker gene heat map

### DIFF
--- a/packages/scxa-marker-gene-heatmap/package.json
+++ b/packages/scxa-marker-gene-heatmap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebi-gene-expression-group/scxa-marker-gene-heatmap",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/scxa-marker-gene-heatmap/src/MarkerGeneHeatmap.js
+++ b/packages/scxa-marker-gene-heatmap/src/MarkerGeneHeatmap.js
@@ -96,20 +96,19 @@ const MarkerGeneHeatmap = (props) => {
       const color = `#000000`
       const zIndex = 5
       const splitCellTypeLabel = splitPhrase(heatmapOptionsProvider[heatmapType].labelsFormatter(cellTypeOrClusterId))
+      const shortenCellTypeLabel = splitCellTypeLabel.length <= 3 ? splitCellTypeLabel.join(`<br/>`) : splitCellTypeLabel.slice(0, 3).join(`<br/>`) + `...`
       plotLines.push({
         color,
         width: 2,
         value: plotLineAxisPosition,
         zIndex,
         label: heatmapType !== `multiexperimentcelltypes` && {
-          // tilted and trim very long labels for long cell types
-          text: splitCellTypeLabel.length <= 3 ? splitCellTypeLabel.join(`<br/>`) : splitCellTypeLabel.slice(0, 3).join(`<br/>`) + `...`,
+          text: shortenCellTypeLabel,
           align: `right`,
           textAlign: `left`,
           rotation: heatmapType === `celltypes` ? -45 : 0,
           x: heatmapType === `celltypes` ? 3 : 0,
-          // No need to move very long labels slightly up as we tilted and trim it for long cell types
-          y: yOffset //- Math.max(splitCellTypeLabel.length - 3, 0) * heatmapRowHeight / 2
+          y: yOffset
         }
       })
     })

--- a/packages/scxa-marker-gene-heatmap/src/MarkerGeneHeatmap.js
+++ b/packages/scxa-marker-gene-heatmap/src/MarkerGeneHeatmap.js
@@ -102,11 +102,14 @@ const MarkerGeneHeatmap = (props) => {
         value: plotLineAxisPosition,
         zIndex,
         label: heatmapType !== `multiexperimentcelltypes` && {
-          text: splitCellTypeLabel.join(`<br/>`),
+          // tilted and trim very long labels for long cell types
+          text: splitCellTypeLabel.length <= 3 ? splitCellTypeLabel.join(`<br/>`) : splitCellTypeLabel.slice(0, 3).join(`<br/>`) + `...`,
           align: `right`,
           textAlign: `left`,
-          x: 0,
-          y: yOffset - Math.max(splitCellTypeLabel.length - 3, 0) * heatmapRowHeight / 2 // Move very long labels slightly up
+          rotation: heatmapType === `celltypes` ? -45 : 0,
+          x: heatmapType === `celltypes` ? 3 : 0,
+          // No need to move very long labels slightly up as we tilted and trim it for long cell types
+          y: yOffset //- Math.max(splitCellTypeLabel.length - 3, 0) * heatmapRowHeight / 2
         }
       })
     })


### PR DESCRIPTION
We had some UI issues in cell-type marker gene heatmap, while the cell type name is too long, and it will be overlapped with each other and users may not read it properly.

Given the discussion in the team meeting, we agreed that to make the cell type name at the right side column, tilted a bit like the title at the top row, and if it's still too long, we need to use `...` to shorten it.

Regarding the tests, actually, we just need to update the snapshots but we do not have any test configuration yet, this issue will be fixed in my another PR https://github.com/ebi-gene-expression-group/atlas-components/pull/178. I will suggest we do not worry the tests for this PR yet, and  we can upate the snapshots in the test refactoring PR instead.