### PR TITLE
177 chore refactor scxa marker geneheatmap enzyme tests with react 17

### DIFF
--- a/packages/scxa-marker-gene-heatmap/__test__/CalloutAlert.test.js
+++ b/packages/scxa-marker-gene-heatmap/__test__/CalloutAlert.test.js
@@ -1,30 +1,35 @@
 import React from 'react'
-import Enzyme from 'enzyme'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom' // for matcher like toBeInTheDocument
 import renderer from 'react-test-renderer'
-import { shallow } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
-
 import CalloutAlert from '../src/CalloutAlert'
 
-Enzyme.configure({ adapter: new Adapter() })
-
-describe(`CalloutAlert`, () => {
+describe('CalloutAlert', () => {
   const props = {
     error: {
-      description: `A human-readable description of the error, hopefully useful to the user`,
-      name: `Error name`,
-      message: `Error message`
+      description: 'A human-readable description of the error, hopefully useful to the user',
+      name: 'Error name',
+      message: 'Error message',
     }
   }
 
-  it(`prints all the relevant error information`, () => {
-    const wrapper = shallow(<CalloutAlert {...props} />)
-    expect(wrapper.text()).toMatch(props.error.description)
-    expect(wrapper.text()).toMatch(props.error.name)
-    expect(wrapper.text()).toMatch(props.error.message)
+  it('prints all the relevant error information', () => {
+    render(<CalloutAlert {...props} />)
+
+    expect(screen.getByText((content, element) => {
+      return content.includes(props.error.description)
+    })).toBeInTheDocument()
+
+    expect(screen.getByText((content, element) => {
+      return content.includes(props.error.name)
+    })).toBeInTheDocument()
+
+    expect(screen.getByText((content, element) => {
+      return content.includes(props.error.message)
+    })).toBeInTheDocument()
   })
 
-  it(`matches snapshot`, () => {
+  it('matches snapshot', () => {
     const tree = renderer.create(<CalloutAlert {...props} />).toJSON()
     expect(tree).toMatchSnapshot()
   })

--- a/packages/scxa-marker-gene-heatmap/__test__/CalloutAlert.test.js
+++ b/packages/scxa-marker-gene-heatmap/__test__/CalloutAlert.test.js
@@ -4,16 +4,16 @@ import '@testing-library/jest-dom' // for matcher like toBeInTheDocument
 import renderer from 'react-test-renderer'
 import CalloutAlert from '../src/CalloutAlert'
 
-describe('CalloutAlert', () => {
+describe(`CalloutAlert`, () => {
   const props = {
     error: {
-      description: 'A human-readable description of the error, hopefully useful to the user',
-      name: 'Error name',
-      message: 'Error message',
+      description: `A human-readable description of the error, hopefully useful to the user`,
+      name: `Error name`,
+      message: `Error message`
     }
   }
 
-  it('prints all the relevant error information', () => {
+  it(`prints all the relevant error information`, () => {
     render(<CalloutAlert {...props} />)
 
     expect(screen.getByText((content, element) => {
@@ -29,7 +29,7 @@ describe('CalloutAlert', () => {
     })).toBeInTheDocument()
   })
 
-  it('matches snapshot', () => {
+  it(`matches snapshot`, () => {
     const tree = renderer.create(<CalloutAlert {...props} />).toJSON()
     expect(tree).toMatchSnapshot()
   })

--- a/packages/scxa-marker-gene-heatmap/__test__/CalloutAlert.test.js
+++ b/packages/scxa-marker-gene-heatmap/__test__/CalloutAlert.test.js
@@ -13,7 +13,7 @@ describe(`CalloutAlert`, () => {
     }
   }
 
-  it(`prints all the relevant error information`, () => {
+  test(`prints all the relevant error information`, () => {
     render(<CalloutAlert {...props} />)
 
     expect(screen.getByText((content, element) => {
@@ -29,7 +29,7 @@ describe(`CalloutAlert`, () => {
     })).toBeInTheDocument()
   })
 
-  it(`matches snapshot`, () => {
+  test(`matches snapshot`, () => {
     const tree = renderer.create(<CalloutAlert {...props} />).toJSON()
     expect(tree).toMatchSnapshot()
   })

--- a/packages/scxa-marker-gene-heatmap/__test__/CellTypeMarkerGeneHeatmap.test.js
+++ b/packages/scxa-marker-gene-heatmap/__test__/CellTypeMarkerGeneHeatmap.test.js
@@ -1,37 +1,39 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import MarkerGeneHeatmap from '../src/MarkerGeneHeatmap'
 
 describe(`MarkerGeneHeatmap`, () => {
   test(`creates plot lines for every cell type`, () => {
+    const data = [
+      {
+        x: 0,
+        y: 0,
+        geneName: `foo`,
+        value: 13,
+        cellGroupValue: `1`,
+        cellGroupValueWhereMarker: `1`
+      },
+      {
+        x: 1,
+        y: 1,
+        geneName: `bar`,
+        value: 2,
+        cellGroupValue: `2`,
+        cellGroupValueWhereMarker: `2`
+      },
+      {
+        x: 2,
+        y: 2,
+        geneName: `foobar`,
+        value: 1,
+        cellGroupValue: `3`,
+        cellGroupValueWhereMarker: `3`
+      }
+    ]
     const { container } = render(
       <MarkerGeneHeatmap
-        data={[
-          {
-            x: 0,
-            y: 0,
-            geneName: `foo`,
-            value: 13,
-            cellGroupValue: `1`,
-            cellGroupValueWhereMarker: `1`
-          },
-          {
-            x: 1,
-            y: 1,
-            geneName: `bar`,
-            value: 2,
-            cellGroupValue: `2`,
-            cellGroupValueWhereMarker: `2`
-          },
-          {
-            x: 2,
-            y: 2,
-            geneName: `foobar`,
-            value: 1,
-            cellGroupValue: `3`,
-            cellGroupValueWhereMarker: `3`
-          }
-        ]}
+        data={data}
         xAxisCategories={[`1`, `2`, `3`]}
         yAxisCategories={[`a`, `b`, `c`]}
         chartHeight={200}
@@ -43,10 +45,10 @@ describe(`MarkerGeneHeatmap`, () => {
     )
 
     const plotLines = container.querySelectorAll(`[class^="highcharts-plot-line "]`)
-    expect(plotLines).toHaveLength(3)
+    expect(plotLines).toHaveLength(data.length)
   })
 
-  test(`has data export options and a styled button`, () => {
+  test(`has a download button`, () => {
     const { container } = render(
       <MarkerGeneHeatmap
         data={[
@@ -56,7 +58,8 @@ describe(`MarkerGeneHeatmap`, () => {
             geneName: `foo`,
             value: 13,
             cellGroupValue: `1`,
-            cellGroupValueWhereMarker: `1`
+            cellGroupValueWhereMarker: `1`,
+            expressionUnit: `butter`
           }
         ]}
         xAxisCategories={[`1`, `2`, `3`]}
@@ -68,8 +71,9 @@ describe(`MarkerGeneHeatmap`, () => {
         heatmapType="celltypes"
       />
     )
-
     // Use screen to query the button
-    expect(screen.getByText(`Download`)).toBeInTheDocument()
+    const button = screen.getByText(`Download`)
+    userEvent.click(button)
+    expect(button).toBeInTheDocument()
   })
 })

--- a/packages/scxa-marker-gene-heatmap/__test__/CellTypeMarkerGeneHeatmap.test.js
+++ b/packages/scxa-marker-gene-heatmap/__test__/CellTypeMarkerGeneHeatmap.test.js
@@ -1,92 +1,75 @@
 import React from 'react'
-import Enzyme from 'enzyme'
-import {shallow} from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
-
-import '@babel/polyfill'
+import { render, screen } from '@testing-library/react'
 import MarkerGeneHeatmap from '../src/MarkerGeneHeatmap'
-
-Enzyme.configure({ adapter: new Adapter() })
 
 describe(`MarkerGeneHeatmap`, () => {
   test(`creates plot lines for every cell type`, () => {
-    const wrapper = shallow(<MarkerGeneHeatmap
-      data={[
-        {
-          x: 0,
-          y: 0,
-          geneName: `foo`,
-          value: 13,
-          cellGroupValue: `1`,
-          cellGroupValueWhereMarker: `1`
-        },
-        {
-          x: 1,
-          y: 1,
-          geneName: `bar`,
-          value: 2,
-          cellGroupValue: `2`,
-          cellGroupValueWhereMarker: `2`
-        },
-        {
-          x: 2,
-          y: 2,
-          geneName: `foobar`,
-          value: 1,
-          cellGroupValue: `3`,
-          cellGroupValueWhereMarker: `3`
-        }
-      ]}
-      xAxisCategories={[`1`, `2`, `3`]}
-      yAxisCategories={[`a`, `b`, `c`]}
-      chartHeight={200}
-      heatmapRowHeight={20}
-      hasDynamicHeight={false}
-      species={`species`}
-      heatmapType={`celltypes`} />)
+    const { container } = render(
+      <MarkerGeneHeatmap
+        data={[
+          {
+            x: 0,
+            y: 0,
+            geneName: `foo`,
+            value: 13,
+            cellGroupValue: `1`,
+            cellGroupValueWhereMarker: `1`
+          },
+          {
+            x: 1,
+            y: 1,
+            geneName: `bar`,
+            value: 2,
+            cellGroupValue: `2`,
+            cellGroupValueWhereMarker: `2`
+          },
+          {
+            x: 2,
+            y: 2,
+            geneName: `foobar`,
+            value: 1,
+            cellGroupValue: `3`,
+            cellGroupValueWhereMarker: `3`
+          }
+        ]}
+        xAxisCategories={[`1`, `2`, `3`]}
+        yAxisCategories={[`a`, `b`, `c`]}
+        chartHeight={200}
+        heatmapRowHeight={20}
+        hasDynamicHeight={false}
+        species="species"
+        heatmapType="celltypes"
+      />
+    )
 
-    const chartOptions = wrapper.props().options
-
-    expect(chartOptions.yAxis.plotLines).toHaveLength(3)
+    const plotLines = container.querySelectorAll('[class^="highcharts-plot-line "]')
+    expect(plotLines).toHaveLength(3)
   })
 
-  test(`does have data export options and a styled button`, () => {
-    const wrapper = shallow(<MarkerGeneHeatmap
-      data={[
-        {
-          x: 0,
-          y: 0,
-          geneName: `foo`,
-          value: 13,
-          cellGroupValue: `1`,
-          cellGroupValueWhereMarker: `1`
-        }
-      ]}
-      xAxisCategories={[`1`, `2`, `3`]}
-      yAxisCategories={[`a`, `b`, `c`]}
-      chartHeight={200}
-      heatmapRowHeight={20}
-      hasDynamicHeight={false}
-      species={`species`}
-      heatmapType={`celltypes`} />)
-
-    const chartOptions = wrapper.props().options
-
-    expect(chartOptions.exporting.buttons.contextButton.text).toEqual(
-      `Download`)
-
-    expect(chartOptions.exporting.buttons.contextButton.symbol).toEqual(`download`)
-
-    expect(chartOptions.exporting.buttons.contextButton.menuItems).toEqual(
-      [
-        `downloadPNG`,
-        `downloadJPEG`,
-        `downloadPDF`,
-        `downloadSVG`,
-        `separator`,
-        `downloadCSV`,
-        `downloadXLS`
-      ]
+  test(`has data export options and a styled button`, () => {
+    const { container } = render(
+      <MarkerGeneHeatmap
+        data={[
+          {
+            x: 0,
+            y: 0,
+            geneName: `foo`,
+            value: 13,
+            cellGroupValue: `1`,
+            cellGroupValueWhereMarker: `1`
+          }
+        ]}
+        xAxisCategories={[`1`, `2`, `3`]}
+        yAxisCategories={[`a`, `b`, `c`]}
+        chartHeight={200}
+        heatmapRowHeight={20}
+        hasDynamicHeight={false}
+        species="species"
+        heatmapType="celltypes"
+      />
     )
+
+    // Use screen to query the button
+    expect(screen.getByText(`Download`)).toBeInTheDocument()
   })
 })

--- a/packages/scxa-marker-gene-heatmap/__test__/CellTypeMarkerGeneHeatmap.test.js
+++ b/packages/scxa-marker-gene-heatmap/__test__/CellTypeMarkerGeneHeatmap.test.js
@@ -42,7 +42,7 @@ describe(`MarkerGeneHeatmap`, () => {
       />
     )
 
-    const plotLines = container.querySelectorAll('[class^="highcharts-plot-line "]')
+    const plotLines = container.querySelectorAll(`[class^="highcharts-plot-line "]`)
     expect(plotLines).toHaveLength(3)
   })
 

--- a/packages/scxa-marker-gene-heatmap/__test__/HeatmapView.test.js
+++ b/packages/scxa-marker-gene-heatmap/__test__/HeatmapView.test.js
@@ -1,42 +1,41 @@
 import React from 'react'
-import Enzyme, {mount} from 'enzyme'
-import {shallow} from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
-
-import '@babel/polyfill'
+import { render, screen } from '@testing-library/react'
 import fetchMock from 'fetch-mock'
-
 import HeatmapView from '../src/HeatmapView'
-import CalloutAlert from '../src/CalloutAlert'
 
-Enzyme.configure({ adapter: new Adapter() })
+describe('HeatmapView', () => {
+  const props = {
+    host: 'foo/',
+    resource: 'bar',
+    species: 'species',
+    heatmapType: 'clusters',
+  }
 
-describe(`HeatmapView`, () => {
   beforeEach(() => {
     fetchMock.restore()
   })
 
-  const props = {
-    host: `foo/`,
-    resource: `bar`,
-    species: `species`,
-    heatmapType: `clusters`
-  }
+  test('renders error if API request is unsuccessful', () => {
+    render(<HeatmapView {...props} />)
 
-  test(`renders error if API request is unsuccessful`, () => {
-    const wrapper = shallow(<HeatmapView {...props} />)
-    expect(wrapper.exists(CalloutAlert)).toBe(true)
+    // Check if CalloutAlert is rendered
+    expect(screen.getByText((content, element) => {
+      return content.includes(`Error`)
+    })).toBeInTheDocument()
   })
 
-  test(`matches snapshot when heatmap type is multiexperimentcelltypes`, () => {
-    expect(mount(<HeatmapView {...props} heatmapType={`multiexperimentcelltypes`}/>)).toMatchSnapshot()
+  test('matches snapshot when heatmap type is multiexperimentcelltypes', () => {
+    const { asFragment } = render(<HeatmapView {...props} heatmapType="multiexperimentcelltypes" />)
+    expect(asFragment()).toMatchSnapshot()
   })
 
-  test(`matches snapshot when heatmap type is clusters`, () => {
-    expect(mount(<HeatmapView {...props} heatmapType={`clusters`}/>)).toMatchSnapshot()
+  test('matches snapshot when heatmap type is clusters', () => {
+    const { asFragment } = render(<HeatmapView {...props} heatmapType="clusters" />)
+    expect(asFragment()).toMatchSnapshot()
   })
 
-  test(`matches snapshot when heatmap type is celltypes`, () => {
-    expect(mount(<HeatmapView {...props} heatmapType={`celltypes`}/>)).toMatchSnapshot()
+  test('matches snapshot when heatmap type is celltypes', () => {
+    const { asFragment } = render(<HeatmapView {...props} heatmapType="celltypes" />)
+    expect(asFragment()).toMatchSnapshot()
   })
 })

--- a/packages/scxa-marker-gene-heatmap/__test__/HeatmapView.test.js
+++ b/packages/scxa-marker-gene-heatmap/__test__/HeatmapView.test.js
@@ -3,19 +3,19 @@ import { render, screen } from '@testing-library/react'
 import fetchMock from 'fetch-mock'
 import HeatmapView from '../src/HeatmapView'
 
-describe('HeatmapView', () => {
+describe(`HeatmapView`, () => {
   const props = {
-    host: 'foo/',
-    resource: 'bar',
-    species: 'species',
-    heatmapType: 'clusters',
+    host: `foo/`,
+    resource: `bar`,
+    species: `species`,
+    heatmapType: `clusters`
   }
 
   beforeEach(() => {
     fetchMock.restore()
   })
 
-  test('renders error if API request is unsuccessful', () => {
+  test(`renders error if API request is unsuccessful`, () => {
     render(<HeatmapView {...props} />)
 
     // Check if CalloutAlert is rendered
@@ -24,17 +24,17 @@ describe('HeatmapView', () => {
     })).toBeInTheDocument()
   })
 
-  test('matches snapshot when heatmap type is multiexperimentcelltypes', () => {
+  test(`matches snapshot when heatmap type is multiexperimentcelltypes`, () => {
     const { asFragment } = render(<HeatmapView {...props} heatmapType="multiexperimentcelltypes" />)
     expect(asFragment()).toMatchSnapshot()
   })
 
-  test('matches snapshot when heatmap type is clusters', () => {
+  test(`matches snapshot when heatmap type is clusters`, () => {
     const { asFragment } = render(<HeatmapView {...props} heatmapType="clusters" />)
     expect(asFragment()).toMatchSnapshot()
   })
 
-  test('matches snapshot when heatmap type is celltypes', () => {
+  test(`matches snapshot when heatmap type is celltypes`, () => {
     const { asFragment } = render(<HeatmapView {...props} heatmapType="celltypes" />)
     expect(asFragment()).toMatchSnapshot()
   })

--- a/packages/scxa-marker-gene-heatmap/__test__/LoadingOverlay.test.js
+++ b/packages/scxa-marker-gene-heatmap/__test__/LoadingOverlay.test.js
@@ -3,13 +3,13 @@ import { render } from '@testing-library/react'
 
 import LoadingOverlay from '../src/LoadingOverlay'
 
-describe('LoadingOverlay', () => {
-  test('matches snapshot when shown', () => {
+describe(`LoadingOverlay`, () => {
+  test(`matches snapshot when shown`, () => {
     const { asFragment } = render(<LoadingOverlay show={true} />)
     expect(asFragment()).toMatchSnapshot()
   })
 
-  test('matches snapshot when hidden', () => {
+  test(`matches snapshot when hidden`, () => {
     const { asFragment } = render(<LoadingOverlay show={false} />)
     expect(asFragment()).toMatchSnapshot()
   })

--- a/packages/scxa-marker-gene-heatmap/__test__/LoadingOverlay.test.js
+++ b/packages/scxa-marker-gene-heatmap/__test__/LoadingOverlay.test.js
@@ -1,14 +1,16 @@
 import React from 'react'
-import { mount } from 'enzyme'
+import { render } from '@testing-library/react'
 
 import LoadingOverlay from '../src/LoadingOverlay'
 
-describe(`LoadingOverlay`, () => {
-  test(`matches snapshot when shown`, () => {
-    expect(mount(<LoadingOverlay show={true}/>)).toMatchSnapshot()
+describe('LoadingOverlay', () => {
+  test('matches snapshot when shown', () => {
+    const { asFragment } = render(<LoadingOverlay show={true} />)
+    expect(asFragment()).toMatchSnapshot()
   })
 
-  test(`matches snapshot when hidden`, () => {
-    expect(mount(<LoadingOverlay show={false}/>)).toMatchSnapshot()
+  test('matches snapshot when hidden', () => {
+    const { asFragment } = render(<LoadingOverlay show={false} />)
+    expect(asFragment()).toMatchSnapshot()
   })
 })

--- a/packages/scxa-marker-gene-heatmap/__test__/__snapshots__/HeatmapView.test.js.snap
+++ b/packages/scxa-marker-gene-heatmap/__test__/__snapshots__/HeatmapView.test.js.snap
@@ -1,163 +1,103 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`HeatmapView matches snapshot when heatmap type is celltypes 1`] = `
-<HeatmapView
-  defaultHeatmapHeight={300}
-  hasDynamicHeight={true}
-  heatmapRowHeight={20}
-  heatmapType="celltypes"
-  host="foo/"
-  plotWrapperClassName=""
-  resource="bar"
-  species="species"
-  wrapperClassName=""
->
-  <CalloutAlert
-    error={
-      Object {
-        "description": "There was a problem communicating with the server. Please try again later.",
-        "message": "fetch is not defined",
-        "name": "ReferenceError",
-      }
-    }
+<DocumentFragment>
+  <div
+    class="row"
   >
     <div
-      className="row"
+      class="columns large-9 large-centered"
     >
       <div
-        className="columns large-9 large-centered"
+        class="callout alert small"
       >
-        <div
-          className="callout alert small"
-        >
-          <h5>
-            Oops!
-          </h5>
-          <p>
-            There was a problem communicating with the server. Please try again later.
-            <br />
-            If the error persists, in order to help us debug the issue, please copy the URL and this message and send it to us via 
-            <a
-              href="https://www.ebi.ac.uk/support/gxasc"
-            >
-              the EBI Support & Feedback system
-            </a>
-            :
-          </p>
-          <code>
-            ReferenceError: fetch is not defined
-          </code>
-        </div>
+        <h5>
+          Oops!
+        </h5>
+        <p>
+          There was a problem communicating with the server. Please try again later.
+          <br />
+          If the error persists, in order to help us debug the issue, please copy the URL and this message and send it to us via 
+          <a
+            href="https://www.ebi.ac.uk/support/gxasc"
+          >
+            the EBI Support & Feedback system
+          </a>
+          :
+        </p>
+        <code>
+          ReferenceError: fetch is not defined
+        </code>
       </div>
     </div>
-  </CalloutAlert>
-</HeatmapView>
+  </div>
+</DocumentFragment>
 `;
 
 exports[`HeatmapView matches snapshot when heatmap type is clusters 1`] = `
-<HeatmapView
-  defaultHeatmapHeight={300}
-  hasDynamicHeight={true}
-  heatmapRowHeight={20}
-  heatmapType="clusters"
-  host="foo/"
-  plotWrapperClassName=""
-  resource="bar"
-  species="species"
-  wrapperClassName=""
->
-  <CalloutAlert
-    error={
-      Object {
-        "description": "There was a problem communicating with the server. Please try again later.",
-        "message": "fetch is not defined",
-        "name": "ReferenceError",
-      }
-    }
+<DocumentFragment>
+  <div
+    class="row"
   >
     <div
-      className="row"
+      class="columns large-9 large-centered"
     >
       <div
-        className="columns large-9 large-centered"
+        class="callout alert small"
       >
-        <div
-          className="callout alert small"
-        >
-          <h5>
-            Oops!
-          </h5>
-          <p>
-            There was a problem communicating with the server. Please try again later.
-            <br />
-            If the error persists, in order to help us debug the issue, please copy the URL and this message and send it to us via 
-            <a
-              href="https://www.ebi.ac.uk/support/gxasc"
-            >
-              the EBI Support & Feedback system
-            </a>
-            :
-          </p>
-          <code>
-            ReferenceError: fetch is not defined
-          </code>
-        </div>
+        <h5>
+          Oops!
+        </h5>
+        <p>
+          There was a problem communicating with the server. Please try again later.
+          <br />
+          If the error persists, in order to help us debug the issue, please copy the URL and this message and send it to us via 
+          <a
+            href="https://www.ebi.ac.uk/support/gxasc"
+          >
+            the EBI Support & Feedback system
+          </a>
+          :
+        </p>
+        <code>
+          ReferenceError: fetch is not defined
+        </code>
       </div>
     </div>
-  </CalloutAlert>
-</HeatmapView>
+  </div>
+</DocumentFragment>
 `;
 
 exports[`HeatmapView matches snapshot when heatmap type is multiexperimentcelltypes 1`] = `
-<HeatmapView
-  defaultHeatmapHeight={300}
-  hasDynamicHeight={true}
-  heatmapRowHeight={20}
-  heatmapType="multiexperimentcelltypes"
-  host="foo/"
-  plotWrapperClassName=""
-  resource="bar"
-  species="species"
-  wrapperClassName=""
->
-  <CalloutAlert
-    error={
-      Object {
-        "description": "There was a problem communicating with the server. Please try again later.",
-        "message": "fetch is not defined",
-        "name": "ReferenceError",
-      }
-    }
+<DocumentFragment>
+  <div
+    class="row"
   >
     <div
-      className="row"
+      class="columns large-9 large-centered"
     >
       <div
-        className="columns large-9 large-centered"
+        class="callout alert small"
       >
-        <div
-          className="callout alert small"
-        >
-          <h5>
-            Oops!
-          </h5>
-          <p>
-            There was a problem communicating with the server. Please try again later.
-            <br />
-            If the error persists, in order to help us debug the issue, please copy the URL and this message and send it to us via 
-            <a
-              href="https://www.ebi.ac.uk/support/gxasc"
-            >
-              the EBI Support & Feedback system
-            </a>
-            :
-          </p>
-          <code>
-            ReferenceError: fetch is not defined
-          </code>
-        </div>
+        <h5>
+          Oops!
+        </h5>
+        <p>
+          There was a problem communicating with the server. Please try again later.
+          <br />
+          If the error persists, in order to help us debug the issue, please copy the URL and this message and send it to us via 
+          <a
+            href="https://www.ebi.ac.uk/support/gxasc"
+          >
+            the EBI Support & Feedback system
+          </a>
+          :
+        </p>
+        <code>
+          ReferenceError: fetch is not defined
+        </code>
       </div>
     </div>
-  </CalloutAlert>
-</HeatmapView>
+  </div>
+</DocumentFragment>
 `;

--- a/packages/scxa-marker-gene-heatmap/__test__/__snapshots__/LoadingOverlay.test.js.snap
+++ b/packages/scxa-marker-gene-heatmap/__test__/__snapshots__/LoadingOverlay.test.js.snap
@@ -1,45 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`LoadingOverlay matches snapshot when hidden 1`] = `
-<LoadingOverlay
-  resourcesUrl=""
-  show={false}
->
-  <styled.div
-    show={false}
+<DocumentFragment>
+  <div
+    class="sc-aXZVg kYawNo"
   >
-    <div
-      className="sc-bdnylx bqQJZW"
-    >
-      <p>
-        Loading, please wait...
-      </p>
-      <img
-        src="test-file-stub"
-      />
-    </div>
-  </styled.div>
-</LoadingOverlay>
+    <p>
+      Loading, please wait...
+    </p>
+    <img
+      src="test-file-stub"
+    />
+  </div>
+</DocumentFragment>
 `;
 
 exports[`LoadingOverlay matches snapshot when shown 1`] = `
-<LoadingOverlay
-  resourcesUrl=""
-  show={true}
->
-  <styled.div
-    show={true}
+<DocumentFragment>
+  <div
+    class="sc-aXZVg bGqqkF"
   >
-    <div
-      className="sc-bdnylx dRCoQz"
-    >
-      <p>
-        Loading, please wait...
-      </p>
-      <img
-        src="test-file-stub"
-      />
-    </div>
-  </styled.div>
-</LoadingOverlay>
+    <p>
+      Loading, please wait...
+    </p>
+    <img
+      src="test-file-stub"
+    />
+  </div>
+</DocumentFragment>
 `;

--- a/packages/scxa-marker-gene-heatmap/package.json
+++ b/packages/scxa-marker-gene-heatmap/package.json
@@ -7,9 +7,25 @@
   "description": "Single Cell Expression Atlas experiment cell type marker genes heatmap",
   "main": "lib/index.js",
   "scripts": {
-    "prepare": "rm -rf lib && babel src -d lib --copy-files"
+    "prepare": "rm -rf lib && babel src -d lib --copy-files",
+    "test": "jest -u"
   },
-  "jest": {},
+  "jest": {
+    "setupFilesAfterEnv": [
+      "@testing-library/jest-dom"
+    ],
+    "testEnvironment": "jsdom",
+    "transform": {
+      "^.+\\.(js|jsx)$": "babel-jest"
+    },
+    "transformIgnorePatterns": [
+      "/node_modules/(?!(cheerio)/)"
+    ],
+    "moduleNameMapper": {
+      "\\.(css|less|scss|sass)$": "identity-obj-proxy",
+      "\\.(gif|jpg|jpeg|png|svg)$": "<rootDir>/__mocks__/fileMock.js"
+    }
+  },
   "author": "Expression Atlas developers <arrayexpress-atlas@ebi.ac.uk>",
   "collaborators": [
     "Lingyun Zhao <lingyun@ebi.ac.uk>",
@@ -22,6 +38,7 @@
     "url": "git+https://github.com/ebi-gene-expression-group/atlas-components.git"
   },
   "dependencies": {
+    "babel-jest": "^29.7.0",
     "highcharts": "^10.1.0",
     "highcharts-react-official": "^3.1.0",
     "lodash": "^4.17.21",
@@ -38,10 +55,15 @@
     "@babel/preset-env": "^7.18.6",
     "@babel/preset-react": "^7.18.6",
     "@ebi-gene-expression-group/eslint-config": "^3.3.0",
+    "@testing-library/jest-dom": "^6.5.0",
+    "@testing-library/react": "^12.1.5",
     "babel-loader": "^8.2.5",
     "eslint": "^8.18.0",
+    "fetch-mock": "^9.10.6",
     "file-loader": "^6.2.0",
     "jest": "^28.1.1",
+    "jest-environment-jsdom": "^29.7.0",
+    "jest-fetch-mock": "^3.0.3",
     "react-test-renderer": "^17.0.2",
     "webpack": "^5.73.0",
     "webpack-cli": "^4.10.0",

--- a/packages/scxa-marker-gene-heatmap/package.json
+++ b/packages/scxa-marker-gene-heatmap/package.json
@@ -57,6 +57,7 @@
     "@ebi-gene-expression-group/eslint-config": "^3.3.0",
     "@testing-library/jest-dom": "^6.5.0",
     "@testing-library/react": "^12.1.5",
+    "@testing-library/user-event": "^14.5.2",
     "babel-loader": "^8.2.5",
     "eslint": "^8.18.0",
     "fetch-mock": "^9.10.6",


### PR DESCRIPTION
We used `enzyme` before to test marker-gene-heatmap component, which is based on React 16, and since we updated the react into 17, the tests had been suspended, in another word, we do not have any tests for this component currently.

To make a running jest tests again, I found out that `@testing-library/react` is very convinient and well-documented and keep updated to React. Hence, I refactor this component with TLR.