### PR TITLE
read lists not objects

### DIFF
--- a/packages/scxa-tsne-plot/README.md
+++ b/packages/scxa-tsne-plot/README.md
@@ -10,3 +10,14 @@ Elements use classes from the [EBI Visual Framework](https://github.com/ebiwd/EB
 
 To test this component, please uncomment `HighchartsExporting(Highcharts)
  HighchartsOfflineExporting(Highcharts)   HighchartsBoost(Highcharts)` in `Scatterplot.js` first, as highcharts wrappers are not been supported in the test.
+
+# Getting started
+
+```bash
+cd ../..
+npm install
+lerna install
+cd - 
+npm install
+npm start
+```

--- a/packages/scxa-tsne-plot/src/GeneExpressionTSnePlot.js
+++ b/packages/scxa-tsne-plot/src/GeneExpressionTSnePlot.js
@@ -55,28 +55,32 @@ const _colourizeExpressionLevel = (highlightSeries) => {
       return {
         name: aSeries.name,
         data: aSeries.data.map((point) => {
-          if (point.expressionLevel > 0.1) {
-            return {
-              ...point,
-              expressionLevel: Math.round10(point.expressionLevel, -2),
-              color: _colorize(point.expressionLevel)
-            }
-          } else {
-            delete point.expressionLevel
-            return {
-              ...point,
-              color: Color(`lightgrey`).alpha(0.65).rgb().toString()
-            }
-          }
-
+              if (point[3] > 0.1) {
+                return {
+                  x:point[0],
+                  y:point[1],
+                  name:point[2],
+                  expressionLevel: Math.round10(point[3], -2),
+                  color: _colorize(point[3])
+                }
+              } else {
+                delete point[3]
+                return {
+                  x:point[0],
+                  y:point[1],
+                  name:point[2],
+                  color: Color(`lightgrey`).alpha(0.65).rgb().toString()
+                }
+              }
         })
       }
     } else {
       return {
         name: aSeries.name,
         data: aSeries.data.map((point) => ({
-          ...point,
-          expressionLevel: Math.round10(point.expressionLevel, -2),
+          x:point[0],
+          y:point[1],
+          expressionLevel: Math.round10(point[3], -2),
           color: Color(`lightgrey`).alpha(0.65).rgb().toString()
         }))
       }


### PR DESCRIPTION
read the `/experiment`'s series data as a list of lists rather than a list of objects as part of performance improvements.

see ebi-gene-expression-group/atlas-web-single-cell#503
