### PR TITLE
Bugfix cell plots tooltip cell id undefined

### DIFF
--- a/packages/scxa-tsne-plot/src/ClusterTSnePlot.js
+++ b/packages/scxa-tsne-plot/src/ClusterTSnePlot.js
@@ -167,12 +167,14 @@ const ClusterTSnePlot = (props) => {
 
   const afterRender = (chart) => {
     chart.series.forEach(series => {
-      const legendSymbolSize = 10
-      series.legendSymbol.translate(
-          (series.legendSymbol.width / 2) - legendSymbolSize / 2,
-          (series.legendSymbol.height / 2) - legendSymbolSize / 2)
-      series.legendSymbol.attr(`width`, legendSymbolSize)
-      series.legendSymbol.attr(`height`, legendSymbolSize)
+      if (series.legendSymbol) {
+        const legendSymbolSize = 10
+        series.legendSymbol.translate(
+            (series.legendSymbol.width / 2) - legendSymbolSize / 2,
+            (series.legendSymbol.height / 2) - legendSymbolSize / 2)
+        series.legendSymbol.attr(`width`, legendSymbolSize)
+        series.legendSymbol.attr(`height`, legendSymbolSize)
+      }
     })
   }
 

--- a/packages/scxa-tsne-plot/src/ClusterTSnePlot.js
+++ b/packages/scxa-tsne-plot/src/ClusterTSnePlot.js
@@ -55,6 +55,10 @@ const ClusterTSnePlot = (props) => {
 
   const highchartsConfig = {
     plotOptions: {
+      series: {
+        turboThreshold: 0, // disables turbo so name stays intact
+        boostThreshold: 0
+      },
       scatter: {
         marker: {
           symbol: `circle`

--- a/packages/scxa-tsne-plot/src/GeneExpressionTSnePlot.js
+++ b/packages/scxa-tsne-plot/src/GeneExpressionTSnePlot.js
@@ -130,7 +130,9 @@ const GeneExpressionScatterPlot = (props) => {
     },
     plotOptions: {
       series: {
-        colorKey: `expressionLevel`
+        colorKey: `expressionLevel`,
+        turboThreshold: 0, // disables turbo so name stays intact
+        boostThreshold: 0
       }
     },
     colorAxis: plotIsDisabled ?


### PR DESCRIPTION
Due to the `highcharts` package version update, the cell plots tooltip is not working well for large dataset. It's not from the refactoring json format, but the recent highcharts updates. Once it is over 50K, highcharts would drop unnecessary (while he thinks) fields from series data to provide better performance. 